### PR TITLE
Fix return statements for nested scopes

### DIFF
--- a/src/main/java/com/colossalg/dataTypes/functions/JocksUserLandFunction.java
+++ b/src/main/java/com/colossalg/dataTypes/functions/JocksUserLandFunction.java
@@ -31,29 +31,19 @@ public class JocksUserLandFunction extends JocksFunction {
 
     @Override
     public JocksValue call(List<JocksValue> arguments) {
-        final var oldSymbolTable = _interpreter.getSymbolTable();
-        _interpreter.setSymbolTable(new SymbolTable(_symbolTable));
+        return _interpreter.executeUserLandFunction(this, arguments);
+    }
 
-        for (int i = 0; i < _parameters.size(); i++) {
-            _interpreter.getSymbolTable().createVariable(_parameters.get(i), arguments.get(i));
-        }
+    public List<Token> getParameters() {
+        return _parameters;
+    }
 
-        JocksValue result = JocksNil.Instance;
-        for (final var statement : _statements) {
-            // TODO - This currently doesn't support return statements which are
-            //        a child of another statement (if / while / for / block).
-            if (statement instanceof ReturnStatement returnStatement) {
-                if (returnStatement.getSubExpression().isPresent()) {
-                    result = _interpreter.visit(returnStatement.getSubExpression().get());
-                }
-            } else {
-                _interpreter.visit(statement);
-            }
-        }
+    public List<Statement> getStatements() {
+        return _statements;
+    }
 
-        _interpreter.setSymbolTable(oldSymbolTable);
-
-        return result;
+    public SymbolTable getSymbolTable() {
+        return _symbolTable;
     }
 
     // TODO - Revisit this decision.

--- a/src/main/java/com/colossalg/dataTypes/functions/JocksUserLandFunction.java
+++ b/src/main/java/com/colossalg/dataTypes/functions/JocksUserLandFunction.java
@@ -2,8 +2,6 @@ package com.colossalg.dataTypes.functions;
 
 import com.colossalg.Token;
 import com.colossalg.dataTypes.JocksValue;
-import com.colossalg.dataTypes.primitives.JocksNil;
-import com.colossalg.statement.ReturnStatement;
 import com.colossalg.statement.Statement;
 import com.colossalg.visitors.Interpreter;
 import com.colossalg.visitors.SymbolTable;

--- a/src/main/java/com/colossalg/visitors/Interpreter.java
+++ b/src/main/java/com/colossalg/visitors/Interpreter.java
@@ -420,6 +420,7 @@ public class Interpreter implements StatementVisitor<Void>, ExpressionVisitor<Jo
 
     public JocksValue executeUserLandFunction(JocksUserLandFunction function, List<JocksValue> arguments) {
         final var oldSymbolTable = _symbolTable;
+        @SuppressWarnings("UnnecessaryLocalVariable") // I prefer the consistency afforded below by this.
         final var newSymbolTable = new SymbolTable(function.getSymbolTable());
 
         _symbolTable = newSymbolTable;

--- a/src/main/java/com/colossalg/visitors/PrettyPrinter.java
+++ b/src/main/java/com/colossalg/visitors/PrettyPrinter.java
@@ -211,6 +211,7 @@ public class PrettyPrinter implements StatementVisitor<String>, ExpressionVisito
 
     @Override
     public String visitDotExpression(DotExpression expression) {
+        @SuppressWarnings("StringBufferReplaceableByString") // I prefer the consistency with the other methods.
         final var stringBuilder = new StringBuilder();
         stringBuilder.append(visit(expression.getLhsExpression()));
         stringBuilder.append('.');

--- a/test/return_from_for_loop.test
+++ b/test/return_from_for_loop.test
@@ -1,0 +1,16 @@
+fun foo() {
+    for (var i = 0; i < 10; i = i + 1) {
+        if (i >= 5) {
+            return;
+        }
+        print i;
+    }
+    print "This should not print";
+}
+foo();
+---* EXPECT *---
+0.0
+1.0
+2.0
+3.0
+4.0

--- a/test/return_from_function_root.test
+++ b/test/return_from_function_root.test
@@ -1,0 +1,7 @@
+fun foo() {
+    return "bar";
+    print "This should not print.";
+}
+print foo();
+---* EXPECT *---
+bar

--- a/test/return_from_method_root.test
+++ b/test/return_from_method_root.test
@@ -1,0 +1,14 @@
+class Vector2D {
+    fun __init__(self, x, y) {
+        self.x = x;
+        self.y = y;
+    }
+    fun length(self) {
+        return pow(self.x*self.x + self.y*self.y, 0.5);
+        print "This should not print.";
+    }
+}
+var p = new Vector2D(3, 4);
+print p.length();
+---* EXPECT *---
+5.0

--- a/test/return_from_outside_function_or_method.test
+++ b/test/return_from_outside_function_or_method.test
@@ -1,0 +1,5 @@
+{
+    return;
+}
+---* EXPECT *---
+[Resolver] - (:2) - Return statement must be within function scope

--- a/test/return_from_while_loop.test
+++ b/test/return_from_while_loop.test
@@ -1,0 +1,18 @@
+fun foo() {
+    var i = 0;
+    while (i < 10) {
+        if (i >= 5) {
+            return;
+        }
+        print i;
+        i = i + 1;
+    }
+    print "This should not print";
+}
+foo();
+---* EXPECT *---
+0.0
+1.0
+2.0
+3.0
+4.0


### PR DESCRIPTION
This PR fixes up return statements so they can be called from nested scopes (blocks, etc.), not only from the root of a function/method.