### PR TITLE
Fix print statements for JocksClass, JocksFunction and JocksInstance

### DIFF
--- a/src/main/java/com/colossalg/builtin/functions/ToString.java
+++ b/src/main/java/com/colossalg/builtin/functions/ToString.java
@@ -1,0 +1,20 @@
+package com.colossalg.builtin.functions;
+
+import com.colossalg.dataTypes.JocksValue;
+import com.colossalg.dataTypes.functions.JocksJavaLandFunction;
+import com.colossalg.dataTypes.primitives.JocksString;
+
+import java.util.List;
+
+public class ToString extends JocksJavaLandFunction {
+
+    @Override
+    public int getArity() {
+        return 1;
+    }
+
+    @Override
+    public JocksValue call(List<JocksValue> arguments) {
+        return new JocksString(arguments.getFirst().str());
+    }
+}

--- a/src/main/java/com/colossalg/dataTypes/JocksValue.java
+++ b/src/main/java/com/colossalg/dataTypes/JocksValue.java
@@ -12,7 +12,7 @@ public abstract class JocksValue {
     }
 
     public String str() {
-        return getClass().getSimpleName();
+        throw new UnsupportedOperationException("Str is not implemented by " + getClass().getName());
     }
 
     public JocksBool equal(JocksValue other) {

--- a/src/main/java/com/colossalg/dataTypes/classes/JocksClass.java
+++ b/src/main/java/com/colossalg/dataTypes/classes/JocksClass.java
@@ -10,7 +10,7 @@ import java.util.Optional;
 
 public class JocksClass extends JocksValue {
 
-    public JocksClass(Token identifier, Token superClass, HashMap<String, JocksFunction> methods) {
+    public JocksClass(Token identifier, JocksClass superClass, HashMap<String, JocksFunction> methods) {
         _identifier = identifier;
         _superClass = superClass;
         _methods = methods;
@@ -20,21 +20,29 @@ public class JocksClass extends JocksValue {
         }
     }
 
+    @Override
+    public String str() {
+        return String.format("Class(%s)", _identifier.getText());
+    }
+
     public JocksInstance createInstance() {
-        return new JocksInstance(_identifier);
+        return new JocksInstance(this);
     }
 
     public Token getIdentifier() {
         return _identifier;
     }
 
-    public Token getSuperClass() {
-        return _superClass;
-    }
-
     public Optional<JocksFunction> getMethod(String identifier) {
         return Optional.ofNullable(
                 _methods.getOrDefault(identifier, null));
+    }
+
+    public Optional<JocksFunction> getMethodRecursive(String identifier) {
+        return getMethod(identifier)
+                .or(() -> _superClass == null
+                    ? Optional.empty()
+                    : _superClass.getMethodRecursive(identifier));
     }
 
     // TODO - Revisit this decision.
@@ -50,6 +58,6 @@ public class JocksClass extends JocksValue {
     //        the costs, and that the fact that tokens are a pretty thin class
     //        mitigates things somewhat.
     private final Token _identifier;
-    private final Token _superClass;
+    private final JocksClass _superClass;
     private final HashMap<String, JocksFunction> _methods;
 }

--- a/src/main/java/com/colossalg/dataTypes/classes/JocksInstance.java
+++ b/src/main/java/com/colossalg/dataTypes/classes/JocksInstance.java
@@ -16,8 +16,7 @@ public class JocksInstance extends JocksValue {
 
     @Override
     public String str() {
-        final var strMethod = getMethod("__str__")
-                .map((method) -> JocksValue.cast(method, JocksFunction.class));
+        final var strMethod = getMethod("__str__");
         if (strMethod.isPresent()) {
             return strMethod.get().call(new ArrayList<>()).str();
         } else {
@@ -34,7 +33,7 @@ public class JocksInstance extends JocksValue {
         _properties.put(identifier, value);
     }
 
-    public Optional<JocksValue> getMethod(String identifier) {
+    public Optional<JocksFunction> getMethod(String identifier) {
         return _class.getMethodRecursive(identifier)
                 .map((method) -> new BoundMethod(this, method));
     }

--- a/src/main/java/com/colossalg/dataTypes/functions/JocksJavaLandFunction.java
+++ b/src/main/java/com/colossalg/dataTypes/functions/JocksJavaLandFunction.java
@@ -1,5 +1,9 @@
 package com.colossalg.dataTypes.functions;
 
 public abstract class JocksJavaLandFunction extends JocksFunction {
-    // Empty
+
+    @Override
+    public String str() {
+        return "JocksJavaLandFunction";
+    }
 }

--- a/src/main/java/com/colossalg/dataTypes/functions/JocksUserLandFunction.java
+++ b/src/main/java/com/colossalg/dataTypes/functions/JocksUserLandFunction.java
@@ -23,6 +23,11 @@ public class JocksUserLandFunction extends JocksFunction {
     }
 
     @Override
+    public String str() {
+        return "JocksUserLandFunction";
+    }
+
+    @Override
     public int getArity() {
         return _parameters.size();
     }

--- a/src/main/java/com/colossalg/visitors/Resolver.java
+++ b/src/main/java/com/colossalg/visitors/Resolver.java
@@ -30,6 +30,9 @@ public class Resolver implements StatementVisitor<Void>, ExpressionVisitor<Void>
         declareAndDefine("floor");
         declareAndDefine("pow");
 
+        // Strings
+        declareAndDefine("to_string");
+
         // Global Object class which all other classes are descendants of.
         declareAndDefine("Object");
     }

--- a/test/inheritance.test
+++ b/test/inheritance.test
@@ -1,0 +1,49 @@
+class Person {
+    fun __init__(self, first_name, last_name) {
+        self.first_name = first_name;
+        self.last_name  = last_name;
+    }
+    fun get_full_name(self) {
+        return self.first_name + " " + self.last_name;
+    }
+    fun get_details(self) {
+        return "Person: name = " + self.get_full_name() + ".";
+    }
+}
+class Teacher < Person {
+    fun __init__(self, first_name, last_name, grade) {
+        super.__init__(self, first_name, last_name);
+        self.grade = grade;
+    }
+    fun get_details(self) {
+        return "Teacher: name = " + self.get_full_name() + ", grade = " + to_string(self.grade) + ".";
+    }
+}
+class Student < Person {
+    fun __init__(self, first_name, last_name, grade) {
+        super.__init__(self, first_name, last_name);
+        self.grade = grade;
+    }
+    fun get_details(self) {
+        return "Student: name = " + self.get_full_name() + ", grade = " + to_string(self.grade) + ".";
+    }
+}
+# Create and print a Person
+{
+    var p = new Person("John", "Doe");
+    print p.get_details();
+}
+# Create and print a Teacher
+{
+    var p = new Teacher("John", "Doe", 12);
+    print p.get_details();
+}
+# Create and print a Student
+{
+    var p = new Student("John", "Doe", 12);
+    print p.get_details();
+}
+---* EXPECT *---
+Person: name = John Doe.
+Teacher: name = John Doe, grade = 12.0.
+Student: name = John Doe, grade = 12.0.

--- a/test/overload_str.test
+++ b/test/overload_str.test
@@ -1,0 +1,13 @@
+class Vector2D {
+    fun __init__(self, x, y) {
+        self.x = x;
+        self.y = y;
+    }
+    fun __str__(self) {
+        return "Vector2D(" + to_string(self.x) + "," + to_string(self.y) + ")";
+    }
+}
+var v = new Vector2D(1, 2);
+print v;
+---* EXPECT *---
+Vector2D(1.0,2.0)

--- a/test/print_class.test
+++ b/test/print_class.test
@@ -3,4 +3,4 @@ class Dummy {
 }
 print Dummy;
 ---* EXPECT *---
-JocksClass(Dummy)
+Class(Dummy)

--- a/test/print_function.test
+++ b/test/print_function.test
@@ -1,8 +1,0 @@
-fun dummy() {
-    # Empty
-}
-print dummy;
-print isNil;
----* EXPECT *---
-JocksUserLandFunction(dummy)
-JocksBuiltinFunction(isNil)

--- a/test/print_function_from_java_land.test
+++ b/test/print_function_from_java_land.test
@@ -1,0 +1,3 @@
+print isNil;
+---* EXPECT *---
+JocksJavaLandFunction

--- a/test/print_function_from_user_land.test
+++ b/test/print_function_from_user_land.test
@@ -1,0 +1,6 @@
+fun dummy() {
+    # Empty
+}
+print dummy;
+---* EXPECT *---
+JocksUserLandFunction

--- a/test/print_instance.test
+++ b/test/print_instance.test
@@ -1,14 +1,7 @@
-class Point {
-    fun __init__(self, x, y) {
-        self.x = x;
-        self.y = y;
-    }
-
-    fun __str__(self) {
-        return "Point(" + to_string(x) + "," + to_string(y) + ")";
-    }
+class Dummy {
+    # Empty
 }
-var p = new Point(1, 2);
-print p;
+var d = new Dummy();
+print d;
 ---* EXPECT *---
-Point(1,2)
+Instance(Dummy)


### PR DESCRIPTION
This PR fixes up print statements for `JocksClass`, `JocksFunction` (both `JocksJavaLandFunction` and `JocksUserLandFunction`) and `JocksInstance` (even when they override the `__str__` function to tailor the behaviour of `print` and `to_str()` etc.).

To achieve this, I had to revert some decisions I had committed to earlier. Most notably, `JocksClass` and `JocksInstance` now store references to their super class and class via references respectively (rather than tokens). This is because to achieve operator overloading I needed to be able to find methods from within these classes which don't have access to the `SymbolTable` to do the lookup via following names.

I think this is actually a fair bit cleaner, and I can probably reverse enforcing that classes are defined at global scope now because the inheritance hierarchies will no longer suffer from issues of dynamic typing.