### PR TITLE
Clarify the decision for using token identifiers in JocksClass/JocksUserLandFunction

### DIFF
--- a/src/main/java/com/colossalg/dataTypes/classes/JocksClass.java
+++ b/src/main/java/com/colossalg/dataTypes/classes/JocksClass.java
@@ -45,18 +45,6 @@ public class JocksClass extends JocksValue {
                     : _superClass.getMethodRecursive(identifier));
     }
 
-    // TODO - Revisit this decision.
-    //        I'm not 100% sold on my choice here to use the tokens within this class.
-    //        Maybe it's better if the runtime representation of classes doesn't
-    //        contain details from scanning/parsing. It feels that some abstractions
-    //        may be leaking into one another.
-    //        On the other hand, however, propagating the tokens throughout the code
-    //        does make the localization of error messages better as they have the
-    //        file and line.
-    //        I'm hoping this isn't such an irreversible commitment, but I've
-    //        elected to go with it for now, hoping that the benefits outweigh
-    //        the costs, and that the fact that tokens are a pretty thin class
-    //        mitigates things somewhat.
     private final Token _identifier;
     private final JocksClass _superClass;
     private final HashMap<String, JocksFunction> _methods;

--- a/src/main/java/com/colossalg/dataTypes/functions/JocksUserLandFunction.java
+++ b/src/main/java/com/colossalg/dataTypes/functions/JocksUserLandFunction.java
@@ -49,19 +49,6 @@ public class JocksUserLandFunction extends JocksFunction {
         return _symbolTable;
     }
 
-    // TODO - Revisit this decision.
-    //        I'm not 100% sold on my choice here to use the tokens within this class.
-    //        Maybe it's better if the runtime representation of functions doesn't
-    //        contain details from scanning/parsing, besides the statements which
-    //        I don't think there's a way around. It feels that some abstractions
-    //        may be leaking into one another.
-    //        On the other hand, however, propagating the tokens throughout the code
-    //        does make the localization of error messages better as they have the
-    //        file and line.
-    //        I'm hoping this isn't such an irreversible commitment, but I've
-    //        elected to go with it for now, hoping that the benefits outweigh
-    //        the costs, and that the fact that tokens are a pretty thin class
-    //        mitigates things somewhat.
     private final List<Token> _parameters;
     private final List<Statement> _statements;
     private final SymbolTable _symbolTable;

--- a/src/main/java/com/colossalg/visitors/Interpreter.java
+++ b/src/main/java/com/colossalg/visitors/Interpreter.java
@@ -19,13 +19,16 @@ import java.util.function.Supplier;
 public class Interpreter implements StatementVisitor<Void>, ExpressionVisitor<JocksValue> {
 
     public static IllegalStateException createException(String file, int line, String what) {
-        // TODO - I think I should remove this from at leas the public interface of the class.
-        //        Everything outside of the interpreter (symbol table, etc.) should throw an
-        //        exception as normal which should be caught within the interpreter and
-        //        dealt with or propagated respectively.
-        //        Then we probably only need strings rather than tokens in all the runtime
-        //        representation as the exceptions will be caught within the below visitor
-        //        methods where the error localization can be applied.
+        // I don't really like this mechanism, but I think it's a necessary evil (for now at least).
+        // Being able to throw from within the SymbolTable without having to catch it to apply the
+        // localization from within this class makes the visitor methods below much terser.
+        // The unfortunate side effect of this is that the SymbolTable's interface relies on Tokens
+        // rather than Strings for identifiers. This then propagates to JocksClass and
+        // JocksUserLandFunction who have to store their identifier and parameters
+        // respectively as Tokens.
+        // That feels a bit like an abstraction leaking, as Tokens should probably be present during
+        // the static components of the interpreter (scanning, parsing, resolving), but not so much
+        // during runtime.
         return new IllegalStateException(
                 String.format(
                         """


### PR DESCRIPTION
This PR just clarifies some comments regarding my decision to use `Token` in `JocksClass`/`JocksUserLandFunction` which I wasn't originally that happy with and hoped to remove. Trying to shift the error handling strategy such that the `SymbolTable` threw errors as normal which were caught in the `Interpreter` and re-thrown with localization information proved to be ugly, however. I think in the end it's better to allow the `SymbolTable` to throw in the same manor as the `Interpreter` but this means it needs the localization information to be injected.