### PR TITLE
Record call stack for use in error messages

### DIFF
--- a/src/main/java/com/colossalg/Jocks.java
+++ b/src/main/java/com/colossalg/Jocks.java
@@ -55,7 +55,7 @@ public class Jocks {
         try {
             final var interpreter = new Interpreter();
             interpreter.visitAll(statements);
-        } catch (Exception ex) {
+        } catch (RuntimeException ex) {
             System.out.println(ex.getMessage());
         }
     }

--- a/src/main/java/com/colossalg/builtin/functions/BoundMethod.java
+++ b/src/main/java/com/colossalg/builtin/functions/BoundMethod.java
@@ -3,16 +3,21 @@ package com.colossalg.builtin.functions;
 import com.colossalg.dataTypes.JocksValue;
 import com.colossalg.dataTypes.classes.JocksInstance;
 import com.colossalg.dataTypes.functions.JocksFunction;
-import com.colossalg.dataTypes.functions.JocksJavaLandFunction;
 
 import java.util.ArrayList;
 import java.util.List;
 
-public class BoundMethod extends JocksJavaLandFunction {
+public class BoundMethod extends JocksFunction {
 
     public BoundMethod(JocksInstance instance, JocksFunction function) {
+        super(function.getName());
         _instance = instance;
         _function = function;
+    }
+
+    @Override
+    public String str() {
+        return String.format("BoundMethod(%s)", _function.str());
     }
 
     @Override

--- a/src/main/java/com/colossalg/builtin/functions/IsType.java
+++ b/src/main/java/com/colossalg/builtin/functions/IsType.java
@@ -10,7 +10,8 @@ import java.util.List;
 // https://stackoverflow.com/questions/1570073/java-instanceof-and-generics
 public class IsType<T extends JocksValue> extends JocksJavaLandFunction {
 
-    public IsType(Class<T> type) {
+    public IsType(String name, Class<T> type) {
+        super(name);
         _type = type;
     }
 

--- a/src/main/java/com/colossalg/builtin/functions/NoopConstructor.java
+++ b/src/main/java/com/colossalg/builtin/functions/NoopConstructor.java
@@ -8,6 +8,10 @@ import java.util.List;
 
 public class NoopConstructor extends JocksJavaLandFunction {
 
+    public NoopConstructor(String className) {
+        super(className + ".__init__");
+    }
+
     @Override
     public int getArity() {
         return 1;

--- a/src/main/java/com/colossalg/builtin/functions/ToString.java
+++ b/src/main/java/com/colossalg/builtin/functions/ToString.java
@@ -8,6 +8,10 @@ import java.util.List;
 
 public class ToString extends JocksJavaLandFunction {
 
+    public ToString() {
+        super("to_string");
+    }
+
     @Override
     public int getArity() {
         return 1;

--- a/src/main/java/com/colossalg/builtin/functions/maths/Abs.java
+++ b/src/main/java/com/colossalg/builtin/functions/maths/Abs.java
@@ -8,6 +8,10 @@ import java.util.List;
 
 public class Abs extends JocksJavaLandFunction {
 
+    public Abs() {
+        super("abs");
+    }
+
     @Override
     public int getArity() {
         return 1;
@@ -16,7 +20,7 @@ public class Abs extends JocksJavaLandFunction {
     @Override
     public JocksValue call(List<JocksValue> arguments) {
         if (!(arguments.getFirst() instanceof JocksNumber x)) {
-            throw new IllegalStateException("Abs expects arguments to be of type JocksNumber.");
+            throw new IllegalStateException("abs() expects arguments to be of type JocksNumber.");
         }
 
         return new JocksNumber(Math.abs(x.getData()));

--- a/src/main/java/com/colossalg/builtin/functions/maths/Floor.java
+++ b/src/main/java/com/colossalg/builtin/functions/maths/Floor.java
@@ -8,6 +8,10 @@ import java.util.List;
 
 public class Floor extends JocksJavaLandFunction {
 
+    public Floor() {
+        super("floor");
+    }
+
     @Override
     public int getArity() {
         return 1;
@@ -16,7 +20,7 @@ public class Floor extends JocksJavaLandFunction {
     @Override
     public JocksValue call(List<JocksValue> arguments) {
         if (!(arguments.getFirst() instanceof JocksNumber x)) {
-            throw new IllegalStateException("Floor expects arguments to be of type JocksNumber.");
+            throw new IllegalStateException("floor() expects arguments to be of type JocksNumber.");
         }
 
         return new JocksNumber(Math.floor(x.getData()));

--- a/src/main/java/com/colossalg/builtin/functions/maths/Pow.java
+++ b/src/main/java/com/colossalg/builtin/functions/maths/Pow.java
@@ -8,6 +8,10 @@ import java.util.List;
 
 public class Pow extends JocksJavaLandFunction {
 
+    public Pow() {
+        super("pow");
+    }
+
     @Override
     public int getArity() {
         return 2;
@@ -16,7 +20,7 @@ public class Pow extends JocksJavaLandFunction {
     @Override
     public JocksValue call(List<JocksValue> arguments) {
         if (!(arguments.get(0) instanceof JocksNumber x) || !(arguments.get(1) instanceof JocksNumber y)) {
-            throw new IllegalStateException("Pow expects arguments to both be of type JocksNumber.");
+            throw new IllegalStateException("pow() expects arguments to both be of type JocksNumber.");
         }
 
         return new JocksNumber(Math.pow(x.getData(), y.getData()));

--- a/src/main/java/com/colossalg/dataTypes/classes/JocksClass.java
+++ b/src/main/java/com/colossalg/dataTypes/classes/JocksClass.java
@@ -16,7 +16,7 @@ public class JocksClass extends JocksValue {
         _methods = methods;
 
         if (getMethod("__init__").isEmpty()) {
-            _methods.put("__init__", new NoopConstructor());
+            _methods.put("__init__", new NoopConstructor(identifier.getText()));
         }
     }
 

--- a/src/main/java/com/colossalg/dataTypes/classes/JocksClass.java
+++ b/src/main/java/com/colossalg/dataTypes/classes/JocksClass.java
@@ -1,6 +1,5 @@
 package com.colossalg.dataTypes.classes;
 
-import com.colossalg.Token;
 import com.colossalg.builtin.functions.NoopConstructor;
 import com.colossalg.dataTypes.JocksValue;
 import com.colossalg.dataTypes.functions.JocksFunction;
@@ -10,26 +9,26 @@ import java.util.Optional;
 
 public class JocksClass extends JocksValue {
 
-    public JocksClass(Token identifier, JocksClass superClass, HashMap<String, JocksFunction> methods) {
+    public JocksClass(String identifier, JocksClass superClass, HashMap<String, JocksFunction> methods) {
         _identifier = identifier;
         _superClass = superClass;
         _methods = methods;
 
         if (getMethod("__init__").isEmpty()) {
-            _methods.put("__init__", new NoopConstructor(identifier.getText()));
+            _methods.put("__init__", new NoopConstructor(identifier));
         }
     }
 
     @Override
     public String str() {
-        return String.format("Class(%s)", _identifier.getText());
+        return "Class(" + _identifier + ")";
     }
 
     public JocksInstance createInstance() {
         return new JocksInstance(this);
     }
 
-    public Token getIdentifier() {
+    public String getIdentifier() {
         return _identifier;
     }
 
@@ -45,7 +44,7 @@ public class JocksClass extends JocksValue {
                     : _superClass.getMethodRecursive(identifier));
     }
 
-    private final Token _identifier;
+    private final String _identifier;
     private final JocksClass _superClass;
     private final HashMap<String, JocksFunction> _methods;
 }

--- a/src/main/java/com/colossalg/dataTypes/classes/JocksInstance.java
+++ b/src/main/java/com/colossalg/dataTypes/classes/JocksInstance.java
@@ -69,7 +69,7 @@ public class JocksInstance extends JocksValue {
         if (strMethod.isPresent()) {
             return strMethod.get().call(new ArrayList<>()).str();
         } else {
-            return String.format("Instance(%s)", _class.getIdentifier().getText());
+            return String.format("Instance(%s)", _class.getIdentifier());
         }
     }
 
@@ -162,7 +162,7 @@ public class JocksInstance extends JocksValue {
                             "The '%s' operator has not been overridden for the class '%s' or any of its super classes.\n" +
                                     "\tConsider implementing the '%s' method to fix this error.",
                             binaryOperatorTypeToSourceString(operator),
-                            _class.getIdentifier().getText(),
+                            _class.getIdentifier(),
                             binaryOperatorTypeToMethodString(operator)));
         }
     }
@@ -177,7 +177,7 @@ public class JocksInstance extends JocksValue {
                             "The '%s' operator has not been overridden for the class '%s' or any of its super classes.\n" +
                                     "\tConsider implementing the '%s' method to fix this error.",
                             unaryOperatorTypeToSourceString(operator),
-                            _class.getIdentifier().getText(),
+                            _class.getIdentifier(),
                             unaryOperatorTypeToMethodString(operator)));
         }
     }

--- a/src/main/java/com/colossalg/dataTypes/classes/JocksInstance.java
+++ b/src/main/java/com/colossalg/dataTypes/classes/JocksInstance.java
@@ -1,5 +1,6 @@
 package com.colossalg.dataTypes.classes;
 
+import com.colossalg.TokenType;
 import com.colossalg.builtin.functions.BoundMethod;
 import com.colossalg.dataTypes.JocksValue;
 import com.colossalg.dataTypes.functions.JocksFunction;
@@ -9,6 +10,54 @@ import java.util.HashMap;
 import java.util.Optional;
 
 public class JocksInstance extends JocksValue {
+
+    public static String binaryOperatorTypeToSourceString(TokenType operator) {
+        return switch (operator) {
+            case TokenType.EQUAL_EQUAL -> "==";
+            case TokenType.BANGS_EQUAL -> "!=";
+            case TokenType.LESS_THAN -> "<";
+            case TokenType.LESS_THAN_OR_EQUAL -> "<=";
+            case TokenType.MORE_THAN -> ">";
+            case TokenType.MORE_THAN_OR_EQUAL -> ">=";
+            case TokenType.ADD -> "+";
+            case TokenType.SUB -> "-";
+            case TokenType.MUL -> "*";
+            case TokenType.DIV -> "/";
+            default -> "UNKNOWN OPERATOR";
+        };
+    }
+
+    public static String unaryOperatorTypeToSourceString(TokenType operator) {
+        return switch (operator) {
+            case TokenType.ADD -> "+";
+            case TokenType.SUB -> "-";
+            default -> "UNKNOWN OPERATOR";
+        };
+    }
+
+    public static String binaryOperatorTypeToMethodString(TokenType operator) {
+        return switch (operator) {
+            case TokenType.EQUAL_EQUAL -> "__equal__";
+            case TokenType.BANGS_EQUAL -> "__not_equal__";
+            case TokenType.LESS_THAN -> "__less_than__";
+            case TokenType.LESS_THAN_OR_EQUAL -> "__less_than_or_equal__";
+            case TokenType.MORE_THAN -> "__more_than__";
+            case TokenType.MORE_THAN_OR_EQUAL -> "__more_than_or_equal__";
+            case TokenType.ADD -> "__add__";
+            case TokenType.SUB -> "__sub__";
+            case TokenType.MUL -> "__mul__";
+            case TokenType.DIV -> "__div__";
+            default -> "UNKNOWN BINARY OPERATOR";
+        };
+    }
+
+    public static String unaryOperatorTypeToMethodString(TokenType operator) {
+        return switch (operator) {
+            case TokenType.ADD -> "__unary_add__";
+            case TokenType.SUB -> "__unary_sub__";
+            default -> "UNKNOWN UNARY OPERATOR";
+        };
+    }
 
     public JocksInstance(JocksClass jClass) {
         _class = jClass;
@@ -26,62 +75,66 @@ public class JocksInstance extends JocksValue {
 
     @Override
     public JocksValue equal(JocksValue other) {
-        return executeOverloadedBinaryOperator("==", "__equal__", other);
+        return executeOverloadedBinaryOperator(TokenType.EQUAL_EQUAL, other);
     }
 
     @Override
     public JocksValue notEqual(JocksValue other) {
-        return executeOverloadedBinaryOperator("!=", "__not_equal__", other);
+        return executeOverloadedBinaryOperator(TokenType.BANGS_EQUAL, other);
     }
 
     @Override
     public JocksValue lessThan(JocksValue other) {
-        return executeOverloadedBinaryOperator("<", "__less_than__", other);
+        return executeOverloadedBinaryOperator(TokenType.LESS_THAN, other);
     }
 
     @Override
     public JocksValue lessThanOrEqual(JocksValue other) {
-        return executeOverloadedBinaryOperator("<=", "__less_than_or_equal__", other);
+        return executeOverloadedBinaryOperator(TokenType.LESS_THAN_OR_EQUAL, other);
     }
 
     @Override
     public JocksValue moreThan(JocksValue other) {
-        return executeOverloadedBinaryOperator(">", "__more_than__", other);
+        return executeOverloadedBinaryOperator(TokenType.MORE_THAN, other);
     }
 
     @Override
     public JocksValue moreThanOrEqual(JocksValue other) {
-        return executeOverloadedBinaryOperator(">=", "__more_than_or_equal__", other);
+        return executeOverloadedBinaryOperator(TokenType.MORE_THAN_OR_EQUAL, other);
     }
 
     @Override
     public JocksValue add() {
-        return executeOverloadedUnaryOperator("+", "__unary_add__");
+        return executeOverloadedUnaryOperator(TokenType.ADD);
     }
 
     @Override
     public JocksValue add(JocksValue other) {
-        return executeOverloadedBinaryOperator("+", "__add__", other);
+        return executeOverloadedBinaryOperator(TokenType.ADD, other);
     }
 
     @Override
     public JocksValue sub() {
-        return executeOverloadedUnaryOperator("-", "__unary_sub__");
+        return executeOverloadedUnaryOperator(TokenType.SUB);
     }
 
     @Override
     public JocksValue sub(JocksValue other) {
-        return executeOverloadedBinaryOperator("-", "__sub__", other);
+        return executeOverloadedBinaryOperator(TokenType.SUB, other);
     }
 
     @Override
     public JocksValue mul(JocksValue other) {
-        return executeOverloadedBinaryOperator("*", "__mul__", other);
+        return executeOverloadedBinaryOperator(TokenType.MUL, other);
     }
 
     @Override
     public JocksValue div(JocksValue other) {
-        return executeOverloadedBinaryOperator("/", "__div__", other);
+        return executeOverloadedBinaryOperator(TokenType.DIV, other);
+    }
+
+    public JocksClass getJClass() {
+        return _class;
     }
 
     public Optional<JocksValue> getProperty(String identifier) {
@@ -98,8 +151,8 @@ public class JocksInstance extends JocksValue {
                 .map((method) -> new BoundMethod(this, method));
     }
 
-    private JocksValue executeOverloadedBinaryOperator(String operator, String methodName, JocksValue other) {
-        final var method = getMethod(methodName);
+    private JocksValue executeOverloadedBinaryOperator(TokenType operator, JocksValue other) {
+        final var method = getMethod(binaryOperatorTypeToMethodString(operator));
         if (method.isPresent()) {
             final var args = new ArrayList<JocksValue>() {{ add(other); }};
             return method.get().call(args);
@@ -108,14 +161,14 @@ public class JocksInstance extends JocksValue {
                     String.format(
                             "The '%s' operator has not been overridden for the class '%s' or any of its super classes.\n" +
                                     "\tConsider implementing the '%s' method to fix this error.",
-                            operator,
+                            binaryOperatorTypeToSourceString(operator),
                             _class.getIdentifier().getText(),
-                            methodName));
+                            binaryOperatorTypeToMethodString(operator)));
         }
     }
 
-    private JocksValue executeOverloadedUnaryOperator(String operator, String methodName) {
-        final var method = getMethod(methodName);
+    private JocksValue executeOverloadedUnaryOperator(TokenType operator) {
+        final var method = getMethod(unaryOperatorTypeToMethodString(operator));
         if (method.isPresent()) {
             return method.get().call(new ArrayList<>());
         } else {
@@ -123,9 +176,9 @@ public class JocksInstance extends JocksValue {
                     String.format(
                             "The '%s' operator has not been overridden for the class '%s' or any of its super classes.\n" +
                                     "\tConsider implementing the '%s' method to fix this error.",
-                            operator,
+                            unaryOperatorTypeToSourceString(operator),
                             _class.getIdentifier().getText(),
-                            methodName));
+                            unaryOperatorTypeToMethodString(operator)));
         }
     }
 

--- a/src/main/java/com/colossalg/dataTypes/classes/JocksInstance.java
+++ b/src/main/java/com/colossalg/dataTypes/classes/JocksInstance.java
@@ -159,8 +159,9 @@ public class JocksInstance extends JocksValue {
         } else {
             throw new UnsupportedOperationException(
                     String.format(
-                            "The '%s' operator has not been overridden for the class '%s' or any of its super classes.\n" +
-                                    "\tConsider implementing the '%s' method to fix this error.",
+                            """
+                            The '%s' operator has not been overridden for the class '%s' or any of its super classes.
+                            Consider implementing the '%s' method to fix this error.""",
                             binaryOperatorTypeToSourceString(operator),
                             _class.getIdentifier(),
                             binaryOperatorTypeToMethodString(operator)));
@@ -174,8 +175,9 @@ public class JocksInstance extends JocksValue {
         } else {
             throw new UnsupportedOperationException(
                     String.format(
-                            "The '%s' operator has not been overridden for the class '%s' or any of its super classes.\n" +
-                                    "\tConsider implementing the '%s' method to fix this error.",
+                            """
+                            The '%s' operator has not been overridden for the class '%s' or any of its super classes.
+                            Consider implementing the '%s' method to fix this error.""",
                             unaryOperatorTypeToSourceString(operator),
                             _class.getIdentifier(),
                             unaryOperatorTypeToMethodString(operator)));

--- a/src/main/java/com/colossalg/dataTypes/functions/JocksFunction.java
+++ b/src/main/java/com/colossalg/dataTypes/functions/JocksFunction.java
@@ -6,7 +6,17 @@ import java.util.List;
 
 public abstract class JocksFunction extends JocksValue {
 
+    public JocksFunction(String name) {
+        _name = name;
+    }
+
+    public String getName() {
+        return _name;
+    }
+
     public abstract int getArity();
 
     public abstract JocksValue call(List<JocksValue> arguments);
+
+    private final String _name;
 }

--- a/src/main/java/com/colossalg/dataTypes/functions/JocksJavaLandFunction.java
+++ b/src/main/java/com/colossalg/dataTypes/functions/JocksJavaLandFunction.java
@@ -2,8 +2,12 @@ package com.colossalg.dataTypes.functions;
 
 public abstract class JocksJavaLandFunction extends JocksFunction {
 
+    public JocksJavaLandFunction(String name) {
+        super(name);
+    }
+
     @Override
     public String str() {
-        return "JocksJavaLandFunction";
+        return String.format("JocksJavaLandFunction(%s)", getName());
     }
 }

--- a/src/main/java/com/colossalg/dataTypes/functions/JocksUserLandFunction.java
+++ b/src/main/java/com/colossalg/dataTypes/functions/JocksUserLandFunction.java
@@ -11,11 +11,13 @@ import java.util.List;
 public class JocksUserLandFunction extends JocksFunction {
 
     public JocksUserLandFunction(
+            String name,
             List<Token> parameters,
             List<Statement> statements,
             SymbolTable symbolTable,
             Interpreter interpreter
     ) {
+        super(name);
         _parameters = parameters;
         _statements = statements;
         _symbolTable = symbolTable;
@@ -24,7 +26,7 @@ public class JocksUserLandFunction extends JocksFunction {
 
     @Override
     public String str() {
-        return "JocksUserLandFunction";
+        return String.format("JocksUserLandFunction(%s)", getName());
     }
 
     @Override

--- a/src/main/java/com/colossalg/dataTypes/functions/JocksUserLandFunction.java
+++ b/src/main/java/com/colossalg/dataTypes/functions/JocksUserLandFunction.java
@@ -1,6 +1,5 @@
 package com.colossalg.dataTypes.functions;
 
-import com.colossalg.Token;
 import com.colossalg.dataTypes.JocksValue;
 import com.colossalg.statement.Statement;
 import com.colossalg.visitors.Interpreter;
@@ -12,7 +11,7 @@ public class JocksUserLandFunction extends JocksFunction {
 
     public JocksUserLandFunction(
             String name,
-            List<Token> parameters,
+            List<String> parameters,
             List<Statement> statements,
             SymbolTable symbolTable,
             Interpreter interpreter
@@ -39,7 +38,7 @@ public class JocksUserLandFunction extends JocksFunction {
         return _interpreter.executeUserLandFunction(this, arguments);
     }
 
-    public List<Token> getParameters() {
+    public List<String> getParameters() {
         return _parameters;
     }
 
@@ -51,7 +50,7 @@ public class JocksUserLandFunction extends JocksFunction {
         return _symbolTable;
     }
 
-    private final List<Token> _parameters;
+    private final List<String> _parameters;
     private final List<Statement> _statements;
     private final SymbolTable _symbolTable;
     private final Interpreter _interpreter;

--- a/src/main/java/com/colossalg/expression/BinaryExpression.java
+++ b/src/main/java/com/colossalg/expression/BinaryExpression.java
@@ -2,16 +2,13 @@ package com.colossalg.expression;
 
 import com.colossalg.Token;
 
-public class BinaryExpression extends Expression {
+public class BinaryExpression implements Expression {
 
     public BinaryExpression(
-            String file,
-            int line,
             Token operator,
             Expression lftSubExpression,
             Expression rgtSubExpression
     ) {
-        super(file, line);
         _operator = operator;
         _lftSubExpression = lftSubExpression;
         _rgtSubExpression = rgtSubExpression;

--- a/src/main/java/com/colossalg/expression/DotExpression.java
+++ b/src/main/java/com/colossalg/expression/DotExpression.java
@@ -2,15 +2,9 @@ package com.colossalg.expression;
 
 import com.colossalg.Token;
 
-public class DotExpression extends Expression {
+public class DotExpression implements Expression {
 
-    public DotExpression(
-            String file,
-            int line,
-            Expression lhsExpression,
-            Token rhsIdentifier
-    ) {
-        super(file, line);
+    public DotExpression(Expression lhsExpression, Token rhsIdentifier) {
         _lhsExpression = lhsExpression;
         _rhsIdentifier = rhsIdentifier;
     }

--- a/src/main/java/com/colossalg/expression/Expression.java
+++ b/src/main/java/com/colossalg/expression/Expression.java
@@ -1,22 +1,6 @@
 package com.colossalg.expression;
 
-public abstract class Expression {
-
-    Expression(String file, int line) {
-        _file = file;
-        _line = line;
-    }
+public interface Expression {
 
     public abstract <T> T accept(ExpressionVisitor<T> visitor);
-
-    public String getFile() {
-        return _file;
-    }
-
-    public int getLine() {
-        return _line;
-    }
-
-    private final String _file;
-    private final int _line;
 }

--- a/src/main/java/com/colossalg/expression/Expression.java
+++ b/src/main/java/com/colossalg/expression/Expression.java
@@ -2,5 +2,5 @@ package com.colossalg.expression;
 
 public interface Expression {
 
-    public abstract <T> T accept(ExpressionVisitor<T> visitor);
+    <T> T accept(ExpressionVisitor<T> visitor);
 }

--- a/src/main/java/com/colossalg/expression/FunInvocation.java
+++ b/src/main/java/com/colossalg/expression/FunInvocation.java
@@ -2,7 +2,7 @@ package com.colossalg.expression;
 
 import java.util.List;
 
-public class FunInvocation extends Expression {
+public class FunInvocation implements Expression {
 
     public FunInvocation(
             String file,
@@ -10,7 +10,8 @@ public class FunInvocation extends Expression {
             Expression subExpression,
             List<Expression> arguments
     ) {
-        super(file, line);
+        _file = file;
+        _line = line;
         _subExpression = subExpression;
         _arguments  = arguments;
     }
@@ -18,6 +19,14 @@ public class FunInvocation extends Expression {
     @Override
     public <T> T accept(ExpressionVisitor<T> visitor) {
         return visitor.visitFunInvocation(this);
+    }
+
+    public String getFile() {
+        return _file;
+    }
+
+    public int getLine() {
+        return _line;
     }
 
     public Expression getSubExpression() {
@@ -28,6 +37,8 @@ public class FunInvocation extends Expression {
         return _arguments;
     }
 
+    private final String _file;
+    private final int _line;
     private final Expression _subExpression;
     private final List<Expression> _arguments;
 }

--- a/src/main/java/com/colossalg/expression/GroupingExpression.java
+++ b/src/main/java/com/colossalg/expression/GroupingExpression.java
@@ -1,13 +1,8 @@
 package com.colossalg.expression;
 
-public class GroupingExpression extends Expression {
+public class GroupingExpression implements Expression {
 
-    public GroupingExpression(
-            String file,
-            int line,
-            Expression subExpression
-    ) {
-        super(file, line);
+    public GroupingExpression(Expression subExpression) {
         _subExpression = subExpression;
     }
 

--- a/src/main/java/com/colossalg/expression/LiteralExpression.java
+++ b/src/main/java/com/colossalg/expression/LiteralExpression.java
@@ -2,14 +2,9 @@ package com.colossalg.expression;
 
 import com.colossalg.Token;
 
-public class LiteralExpression extends Expression {
+public class LiteralExpression implements Expression {
 
-    public LiteralExpression(
-            String file,
-            int line,
-            Token token
-    ) {
-        super(file, line);
+    public LiteralExpression(Token token) {
         _token = token;
     }
 

--- a/src/main/java/com/colossalg/expression/LogicalExpression.java
+++ b/src/main/java/com/colossalg/expression/LogicalExpression.java
@@ -2,16 +2,13 @@ package com.colossalg.expression;
 
 import com.colossalg.Token;
 
-public class LogicalExpression extends Expression {
+public class LogicalExpression implements Expression {
 
     public LogicalExpression(
-            String file,
-            int line,
             Token operator,
             Expression lftSubExpression,
             Expression rgtSubExpression
     ) {
-        super(file, line);
         _operator = operator;
         _lftSubExpression = lftSubExpression;
         _rgtSubExpression = rgtSubExpression;

--- a/src/main/java/com/colossalg/expression/NewInvocation.java
+++ b/src/main/java/com/colossalg/expression/NewInvocation.java
@@ -4,7 +4,7 @@ import com.colossalg.Token;
 
 import java.util.List;
 
-public class NewInvocation extends Expression {
+public class NewInvocation implements Expression {
 
     public NewInvocation(
             String file,
@@ -12,7 +12,8 @@ public class NewInvocation extends Expression {
             Token identifier,
             List<Expression> arguments
     ) {
-        super(file, line);
+        _file = file;
+        _line = line;
         _identifier = identifier;
         _arguments  = arguments;
     }
@@ -30,6 +31,14 @@ public class NewInvocation extends Expression {
         _symbolTableDepth = symbolTableDepth;
     }
 
+    public String getFile() {
+        return _file;
+    }
+
+    public int getLine() {
+        return _line;
+    }
+
     public Token getIdentifier() {
         return _identifier;
     }
@@ -39,6 +48,8 @@ public class NewInvocation extends Expression {
     }
 
     private int _symbolTableDepth = 0;
+    private final String _file;
+    private final int _line;
     private final Token _identifier;
     private final List<Expression> _arguments;
 }

--- a/src/main/java/com/colossalg/expression/UnaryExpression.java
+++ b/src/main/java/com/colossalg/expression/UnaryExpression.java
@@ -2,15 +2,9 @@ package com.colossalg.expression;
 
 import com.colossalg.Token;
 
-public class UnaryExpression extends Expression {
+public class UnaryExpression implements Expression {
 
-    public UnaryExpression(
-            String file,
-            int line,
-            Token operator,
-            Expression subExpression
-    ) {
-        super(file, line);
+    public UnaryExpression(Token operator, Expression subExpression) {
         _operator = operator;
         _subExpression = subExpression;
     }

--- a/src/main/java/com/colossalg/expression/VarAssignment.java
+++ b/src/main/java/com/colossalg/expression/VarAssignment.java
@@ -1,14 +1,8 @@
 package com.colossalg.expression;
 
-public class VarAssignment extends Expression {
+public class VarAssignment implements Expression {
 
-    public VarAssignment(
-            String file,
-            int line,
-            Expression lhsExpression,
-            Expression rhsExpression
-    ) {
-        super(file, line);
+    public VarAssignment(Expression lhsExpression, Expression rhsExpression) {
         _lhsExpression = lhsExpression;
         _rhsExpression = rhsExpression;
     }

--- a/src/main/java/com/colossalg/expression/VarExpression.java
+++ b/src/main/java/com/colossalg/expression/VarExpression.java
@@ -2,14 +2,9 @@ package com.colossalg.expression;
 
 import com.colossalg.Token;
 
-public class VarExpression extends Expression {
+public class VarExpression implements Expression {
 
-    public VarExpression(
-            String file,
-            int line,
-            Token identifier
-    ) {
-        super(file, line);
+    public VarExpression(Token identifier) {
         _identifier = identifier;
     }
 

--- a/src/main/java/com/colossalg/statement/BlockStatement.java
+++ b/src/main/java/com/colossalg/statement/BlockStatement.java
@@ -2,14 +2,9 @@ package com.colossalg.statement;
 
 import java.util.List;
 
-public class BlockStatement extends Statement {
+public class BlockStatement implements Statement {
 
-    public BlockStatement(
-            String file,
-            int line,
-            List<Statement> subStatements
-    ) {
-        super(file, line);
+    public BlockStatement(List<Statement> subStatements) {
         _subStatements = subStatements;
     }
 

--- a/src/main/java/com/colossalg/statement/ClassDeclaration.java
+++ b/src/main/java/com/colossalg/statement/ClassDeclaration.java
@@ -5,16 +5,13 @@ import com.colossalg.Token;
 import java.util.List;
 import java.util.Optional;
 
-public class ClassDeclaration extends Statement {
+public class ClassDeclaration implements Statement {
 
     public ClassDeclaration(
-            String file,
-            int line,
             Token identifier,
             Token superClass,
             List<FunDeclaration> methods
     ) {
-        super(file, line);
         _identifier = identifier;
         _superClass = superClass;
         _methods = methods;

--- a/src/main/java/com/colossalg/statement/ExpressionStatement.java
+++ b/src/main/java/com/colossalg/statement/ExpressionStatement.java
@@ -2,14 +2,9 @@ package com.colossalg.statement;
 
 import com.colossalg.expression.Expression;
 
-public class ExpressionStatement extends Statement {
+public class ExpressionStatement implements Statement {
 
-    public ExpressionStatement(
-            String file,
-            int line,
-            Expression subExpression
-    ) {
-        super(file, line);
+    public ExpressionStatement(Expression subExpression) {
         _subExpression = subExpression;
     }
 

--- a/src/main/java/com/colossalg/statement/ForStatement.java
+++ b/src/main/java/com/colossalg/statement/ForStatement.java
@@ -4,17 +4,14 @@ import com.colossalg.expression.Expression;
 
 import java.util.Optional;
 
-public class ForStatement extends Statement {
+public class ForStatement implements Statement {
 
     public ForStatement(
-            String file,
-            int line,
             Statement initializer,
             Expression condition,
             Expression increment,
             Statement subStatement
     ) {
-        super(file, line);
         _initializer = initializer;
         _condition = condition;
         _increment = increment;

--- a/src/main/java/com/colossalg/statement/FunDeclaration.java
+++ b/src/main/java/com/colossalg/statement/FunDeclaration.java
@@ -4,16 +4,13 @@ import com.colossalg.Token;
 
 import java.util.List;
 
-public class FunDeclaration extends Statement {
+public class FunDeclaration implements Statement {
 
     public FunDeclaration(
-            String file,
-            int line,
             Token identifier,
             List<Token> parameters,
             List<Statement> statements
     ) {
-        super(file, line);
         _identifier = identifier;
         _parameters = parameters;
         _statements = statements;

--- a/src/main/java/com/colossalg/statement/IfElseStatement.java
+++ b/src/main/java/com/colossalg/statement/IfElseStatement.java
@@ -4,16 +4,13 @@ import com.colossalg.expression.Expression;
 
 import java.util.Optional;
 
-public class IfElseStatement extends Statement {
+public class IfElseStatement implements Statement {
 
     public IfElseStatement(
-            String file,
-            int line,
             Expression condition,
             Statement thenSubStatement,
             Statement elseSubStatement
     ) {
-        super(file, line);
         _condition = condition;
         _thenSubStatement = thenSubStatement;
         _elseSubStatement = elseSubStatement;

--- a/src/main/java/com/colossalg/statement/PrintStatement.java
+++ b/src/main/java/com/colossalg/statement/PrintStatement.java
@@ -2,14 +2,9 @@ package com.colossalg.statement;
 
 import com.colossalg.expression.Expression;
 
-public class PrintStatement extends Statement {
+public class PrintStatement implements Statement {
 
-    public PrintStatement(
-            String file,
-            int line,
-            Expression subExpression
-    ) {
-        super(file, line);
+    public PrintStatement(Expression subExpression) {
         _subExpression = subExpression;
     }
 

--- a/src/main/java/com/colossalg/statement/ReturnStatement.java
+++ b/src/main/java/com/colossalg/statement/ReturnStatement.java
@@ -4,14 +4,15 @@ import com.colossalg.expression.Expression;
 
 import java.util.Optional;
 
-public class ReturnStatement extends Statement {
+public class ReturnStatement implements Statement {
 
     public ReturnStatement(
             String file,
             int line,
             Expression subExpression
     ) {
-        super(file, line);
+        _file = file;
+        _line = line;
         _subExpression = subExpression;
     }
 
@@ -20,9 +21,19 @@ public class ReturnStatement extends Statement {
         return visitor.visitReturnStatement(this);
     }
 
+    public String getFile() {
+        return _file;
+    }
+
+    public int getLine() {
+        return _line;
+    }
+
     public Optional<Expression> getSubExpression() {
         return Optional.ofNullable(_subExpression);
     }
 
+    private final String _file;
+    private final int _line;
     private final Expression _subExpression;
 }

--- a/src/main/java/com/colossalg/statement/Statement.java
+++ b/src/main/java/com/colossalg/statement/Statement.java
@@ -1,22 +1,6 @@
 package com.colossalg.statement;
 
-public abstract class Statement {
-
-    Statement(String file, int line) {
-        _file = file;
-        _line = line;
-    }
+public interface Statement {
 
     public abstract <T> T accept(StatementVisitor<T> visitor);
-
-    public String getFile() {
-        return _file;
-    }
-
-    public int getLine() {
-        return _line;
-    }
-
-    private final String _file;
-    private final int _line;
 }

--- a/src/main/java/com/colossalg/statement/Statement.java
+++ b/src/main/java/com/colossalg/statement/Statement.java
@@ -2,5 +2,5 @@ package com.colossalg.statement;
 
 public interface Statement {
 
-    public abstract <T> T accept(StatementVisitor<T> visitor);
+    <T> T accept(StatementVisitor<T> visitor);
 }

--- a/src/main/java/com/colossalg/statement/VarDeclaration.java
+++ b/src/main/java/com/colossalg/statement/VarDeclaration.java
@@ -3,15 +3,9 @@ package com.colossalg.statement;
 import com.colossalg.Token;
 import com.colossalg.expression.Expression;
 
-public class VarDeclaration extends Statement {
+public class VarDeclaration implements Statement {
 
-    public VarDeclaration(
-            String file,
-            int line,
-            Token identifier,
-            Expression expression
-    ) {
-        super(file, line);
+    public VarDeclaration(Token identifier, Expression expression) {
         _identifier = identifier;
         _expression = expression;
     }

--- a/src/main/java/com/colossalg/statement/WhileStatement.java
+++ b/src/main/java/com/colossalg/statement/WhileStatement.java
@@ -2,15 +2,9 @@ package com.colossalg.statement;
 
 import com.colossalg.expression.Expression;
 
-public class WhileStatement extends Statement {
+public class WhileStatement implements Statement {
 
-    public WhileStatement(
-            String file,
-            int line,
-            Expression condition,
-            Statement subStatement
-    ) {
-        super(file, line);
+    public WhileStatement(Expression condition, Statement subStatement) {
         _condition = condition;
         _subStatement = subStatement;
     }

--- a/src/main/java/com/colossalg/visitors/ExceptionFactory.java
+++ b/src/main/java/com/colossalg/visitors/ExceptionFactory.java
@@ -16,35 +16,29 @@ public class ExceptionFactory {
             String format,
             Object... args
     ) {
-        final var stringBuilder = new StringBuilder();
-        stringBuilder.append(String.format("An internal error was encountered at runtime (%s, %d).\n", file, line));
-        stringBuilder.append(String.format(format, args));
-        stringBuilder.append('\n');
-        stringBuilder.append('\n');
-        stringBuilder.append("Call stack:\n");
-        final var callStackEntryInfo = _getCallStackEntryInfo.get();
-        for (final var info : callStackEntryInfo) {
-            stringBuilder.append('\t');
-            stringBuilder.append(info);
-            stringBuilder.append('\n');
-        }
-        return new RuntimeException(stringBuilder.toString());
+        final var message = String.format(format, args) + "\n\n"
+                + String.format("\tAn internal runtime error was encountered (at line %d of file '%s').\n", line, file)
+                + getCallStackEntryInfoString();
+        return new RuntimeException(message);
     }
 
     public RuntimeException createExceptionWithoutFileOrLine(String format, Object... args) {
+        final var message = String.format(format, args) + "\n\n"
+                + "\tAn internal runtime error was encountered.\n"
+                + getCallStackEntryInfoString();
+        return new RuntimeException(message);
+    }
+
+    private String getCallStackEntryInfoString() {
         final var stringBuilder = new StringBuilder();
-        stringBuilder.append("An internal error was encountered at runtime (%s, %d).\n");
-        stringBuilder.append(String.format(format, args));
-        stringBuilder.append('\n');
-        stringBuilder.append('\n');
-        stringBuilder.append("Call stack:\n");
-        final var callStackEntryInfo = _getCallStackEntryInfo.get();
-        for (final var info : callStackEntryInfo) {
+        stringBuilder.append("\tCall stack:\n");
+        for (final var info : _getCallStackEntryInfo.get()) {
+            stringBuilder.append('\t');
             stringBuilder.append('\t');
             stringBuilder.append(info);
             stringBuilder.append('\n');
         }
-        return new RuntimeException(stringBuilder.toString());
+        return stringBuilder.toString();
     }
 
     private final Supplier<List<String>> _getCallStackEntryInfo;

--- a/src/main/java/com/colossalg/visitors/ExceptionFactory.java
+++ b/src/main/java/com/colossalg/visitors/ExceptionFactory.java
@@ -4,16 +4,6 @@ import java.util.List;
 
 import java.util.function.Supplier;
 
-// I don't really like this mechanism, but I think it's a necessary evil (for now at least).
-// Being able to throw from within the SymbolTable without having to catch it to apply the
-// localization from within this class makes the visitor methods below much terser.
-// The unfortunate side effect of this is that the SymbolTable's interface relies on Tokens
-// rather than Strings for identifiers. This then propagates to JocksClass and
-// JocksUserLandFunction who have to store their identifier and parameters
-// respectively as Tokens.
-// That feels a bit like an abstraction leaking, as Tokens should probably be present during
-// the static components of the interpreter (scanning, parsing, resolving), but not so much
-// during runtime.
 public class ExceptionFactory {
 
     public ExceptionFactory(Supplier<List<String>> getCallStackEntryInfo) {

--- a/src/main/java/com/colossalg/visitors/ExceptionFactory.java
+++ b/src/main/java/com/colossalg/visitors/ExceptionFactory.java
@@ -1,0 +1,35 @@
+package com.colossalg.visitors;
+
+import com.colossalg.expression.Expression;
+import com.colossalg.statement.Statement;
+
+// I don't really like this mechanism, but I think it's a necessary evil (for now at least).
+// Being able to throw from within the SymbolTable without having to catch it to apply the
+// localization from within this class makes the visitor methods below much terser.
+// The unfortunate side effect of this is that the SymbolTable's interface relies on Tokens
+// rather than Strings for identifiers. This then propagates to JocksClass and
+// JocksUserLandFunction who have to store their identifier and parameters
+// respectively as Tokens.
+// That feels a bit like an abstraction leaking, as Tokens should probably be present during
+// the static components of the interpreter (scanning, parsing, resolving), but not so much
+// during runtime.
+public class ExceptionFactory {
+
+    public static RuntimeException createException(
+            String file,
+            int line,
+            String format,
+            Object... args
+    ) {
+        final var what = String.format(format, args);
+        final var message = String.format(
+                """
+                An internal error was encountered at runtime.
+                Where - (%s:%d)
+                What  - %s""",
+                file,
+                line,
+                what);
+        return new RuntimeException(message);
+    }
+}

--- a/src/main/java/com/colossalg/visitors/ExceptionFactory.java
+++ b/src/main/java/com/colossalg/visitors/ExceptionFactory.java
@@ -20,18 +20,33 @@ public class ExceptionFactory {
         _getCallStackEntryInfo = getCallStackEntryInfo;
     }
 
-    public RuntimeException createException(
+    public RuntimeException createExceptionWithFileAndLine(
             String file,
             int line,
             String format,
             Object... args
     ) {
         final var stringBuilder = new StringBuilder();
-        stringBuilder.append("An internal error was encountered at runtime.\n");
+        stringBuilder.append(String.format("An internal error was encountered at runtime (%s, %d).\n", file, line));
         stringBuilder.append(String.format(format, args));
         stringBuilder.append('\n');
         stringBuilder.append('\n');
-        stringBuilder.append(String.format("This occurred at line %d of file '%s'.\n", line, file));
+        stringBuilder.append("Call stack:\n");
+        final var callStackEntryInfo = _getCallStackEntryInfo.get();
+        for (final var info : callStackEntryInfo) {
+            stringBuilder.append('\t');
+            stringBuilder.append(info);
+            stringBuilder.append('\n');
+        }
+        return new RuntimeException(stringBuilder.toString());
+    }
+
+    public RuntimeException createExceptionWithoutFileOrLine(String format, Object... args) {
+        final var stringBuilder = new StringBuilder();
+        stringBuilder.append("An internal error was encountered at runtime (%s, %d).\n");
+        stringBuilder.append(String.format(format, args));
+        stringBuilder.append('\n');
+        stringBuilder.append('\n');
         stringBuilder.append("Call stack:\n");
         final var callStackEntryInfo = _getCallStackEntryInfo.get();
         for (final var info : callStackEntryInfo) {

--- a/src/main/java/com/colossalg/visitors/Interpreter.java
+++ b/src/main/java/com/colossalg/visitors/Interpreter.java
@@ -42,13 +42,13 @@ public class Interpreter implements StatementVisitor<Void>, ExpressionVisitor<Jo
 
     public Interpreter() {
         // Type checking
-        registerInternalVariable("isNil", new IsType<>(JocksNil.class));
-        registerInternalVariable("isBool", new IsType<>(JocksBool.class));
-        registerInternalVariable("isNumber", new IsType<>(JocksNumber.class));
-        registerInternalVariable("isString", new IsType<>(JocksString.class));
-        registerInternalVariable("isInstance", new IsType<>(JocksInstance.class));
-        registerInternalVariable("isFunction", new IsType<>(JocksFunction.class));
-        registerInternalVariable("isClass", new IsType<>(JocksClass.class));
+        registerInternalVariable("is_nil", new IsType<>("is_nil", JocksNil.class));
+        registerInternalVariable("is_bool", new IsType<>("is_bool", JocksBool.class));
+        registerInternalVariable("is_number", new IsType<>("is_number", JocksNumber.class));
+        registerInternalVariable("is_string", new IsType<>("is_string", JocksString.class));
+        registerInternalVariable("is_instance", new IsType<>("is_instance", JocksInstance.class));
+        registerInternalVariable("is_function", new IsType<>("is_function", JocksFunction.class));
+        registerInternalVariable("is_class", new IsType<>("is_class", JocksClass.class));
 
         // Maths
         registerInternalVariable("abs", new Abs());
@@ -96,9 +96,12 @@ public class Interpreter implements StatementVisitor<Void>, ExpressionVisitor<Jo
 
         final var methods = new HashMap<String, JocksFunction>();
         for (final var methodDeclaration : statement.getMethods()) {
+            final var methodName = methodDeclaration.getIdentifier().getText();
             methods.put(
-                    methodDeclaration.getIdentifier().getText(),
-                    funDeclarationToJocksFunction(methodDeclaration));
+                    methodName,
+                    funDeclarationToJocksFunction(
+                            statement.getIdentifier().getText() + "." + methodName,
+                            methodDeclaration));
         }
 
         popSymbolTable();
@@ -115,7 +118,9 @@ public class Interpreter implements StatementVisitor<Void>, ExpressionVisitor<Jo
     public Void visitFunDeclaration(FunDeclaration statement) {
         _symbolTable.createVariable(
                 statement.getIdentifier(),
-                funDeclarationToJocksFunction(statement));
+                funDeclarationToJocksFunction(
+                        statement.getIdentifier().getText(),
+                        statement));
 
         return null;
     }
@@ -494,8 +499,9 @@ public class Interpreter implements StatementVisitor<Void>, ExpressionVisitor<Jo
         _symbolTable.createVariable(createInternalIdentifier(identifier), value);
     }
 
-    private JocksFunction funDeclarationToJocksFunction(FunDeclaration statement) {
+    private JocksFunction funDeclarationToJocksFunction(String functionName, FunDeclaration statement) {
         return new JocksUserLandFunction(
+                functionName,
                 statement.getParameters(),
                 statement.getStatements(),
                 _symbolTable,

--- a/src/main/java/com/colossalg/visitors/Resolver.java
+++ b/src/main/java/com/colossalg/visitors/Resolver.java
@@ -18,13 +18,13 @@ public class Resolver implements StatementVisitor<Void>, ExpressionVisitor<Void>
         begScope(); // Global scope
 
         // Type checking
-        declareAndDefine("isNil");
-        declareAndDefine("isBool");
-        declareAndDefine("isNumber");
-        declareAndDefine("isString");
-        declareAndDefine("isInstance");
-        declareAndDefine("isFunction");
-        declareAndDefine("isClass");
+        declareAndDefine("is_nil");
+        declareAndDefine("is_bool");
+        declareAndDefine("is_number");
+        declareAndDefine("is_string");
+        declareAndDefine("is_instance");
+        declareAndDefine("is_function");
+        declareAndDefine("is_class");
 
         // Maths
         declareAndDefine("abs");

--- a/src/main/java/com/colossalg/visitors/Resolver.java
+++ b/src/main/java/com/colossalg/visitors/Resolver.java
@@ -53,8 +53,8 @@ public class Resolver implements StatementVisitor<Void>, ExpressionVisitor<Void>
             _errorReporter.report(
                     new JocksError(
                         "Resolver",
-                        statement.getFile(),
-                        statement.getLine(),
+                        statement.getIdentifier().getFile(),
+                        statement.getIdentifier().getLine(),
                         "Class declarations are only allowed at the global scope."));
         }
 

--- a/src/main/java/com/colossalg/visitors/SymbolTable.java
+++ b/src/main/java/com/colossalg/visitors/SymbolTable.java
@@ -24,7 +24,7 @@ public class SymbolTable {
 
     public void createVariable(Token identifier, JocksValue value) {
         if (_variables.containsKey(identifier.getText())) {
-            throw _exceptionFactory.createException(
+            throw _exceptionFactory.createExceptionWithFileAndLine(
                     identifier.getFile(),
                     identifier.getLine(),
                     "Attempting to create variable '" + identifier.getText() + "' which already exists in scope");
@@ -35,7 +35,7 @@ public class SymbolTable {
     public JocksValue getVariable(Token identifier) {
         if (!_variables.containsKey(identifier.getText())) {
             if (_parent == null) {
-                throw _exceptionFactory.createException(
+                throw _exceptionFactory.createExceptionWithFileAndLine(
                         identifier.getFile(),
                         identifier.getLine(),
                         "Attempting to get variable '" + identifier.getText() + "' which doesn't exist");
@@ -49,7 +49,7 @@ public class SymbolTable {
     public void setVariable(Token identifier, JocksValue value) {
         if (!_variables.containsKey(identifier.getText())) {
             if (_parent == null) {
-                throw _exceptionFactory.createException(
+                throw _exceptionFactory.createExceptionWithFileAndLine(
                         identifier.getFile(),
                         identifier.getLine(),
                         "Attempting to set variable '" + identifier.getText() + "' which doesn't exist");

--- a/src/main/java/com/colossalg/visitors/SymbolTable.java
+++ b/src/main/java/com/colossalg/visitors/SymbolTable.java
@@ -7,8 +7,9 @@ import java.util.HashMap;
 
 public class SymbolTable {
 
-    public SymbolTable(SymbolTable parent) {
+    public SymbolTable(SymbolTable parent, ExceptionFactory exceptionFactory) {
         _parent = parent;
+        _exceptionFactory = exceptionFactory;
     }
 
     public SymbolTable getParent() {
@@ -23,7 +24,7 @@ public class SymbolTable {
 
     public void createVariable(Token identifier, JocksValue value) {
         if (_variables.containsKey(identifier.getText())) {
-            throw ExceptionFactory.createException(
+            throw _exceptionFactory.createException(
                     identifier.getFile(),
                     identifier.getLine(),
                     "Attempting to create variable '" + identifier.getText() + "' which already exists in scope");
@@ -34,7 +35,7 @@ public class SymbolTable {
     public JocksValue getVariable(Token identifier) {
         if (!_variables.containsKey(identifier.getText())) {
             if (_parent == null) {
-                throw ExceptionFactory.createException(
+                throw _exceptionFactory.createException(
                         identifier.getFile(),
                         identifier.getLine(),
                         "Attempting to get variable '" + identifier.getText() + "' which doesn't exist");
@@ -48,7 +49,7 @@ public class SymbolTable {
     public void setVariable(Token identifier, JocksValue value) {
         if (!_variables.containsKey(identifier.getText())) {
             if (_parent == null) {
-                throw ExceptionFactory.createException(
+                throw _exceptionFactory.createException(
                         identifier.getFile(),
                         identifier.getLine(),
                         "Attempting to set variable '" + identifier.getText() + "' which doesn't exist");
@@ -60,5 +61,6 @@ public class SymbolTable {
     }
 
     private final SymbolTable _parent;
+    private final ExceptionFactory _exceptionFactory;
     private final HashMap<String, JocksValue> _variables = new HashMap<>();
 }

--- a/src/main/java/com/colossalg/visitors/SymbolTable.java
+++ b/src/main/java/com/colossalg/visitors/SymbolTable.java
@@ -1,7 +1,6 @@
 package com.colossalg.visitors;
 
 import com.colossalg.dataTypes.JocksValue;
-import com.colossalg.Token;
 
 import java.util.HashMap;
 
@@ -22,41 +21,35 @@ public class SymbolTable {
                 : this;
     }
 
-    public void createVariable(Token identifier, JocksValue value) {
-        if (_variables.containsKey(identifier.getText())) {
-            throw _exceptionFactory.createExceptionWithFileAndLine(
-                    identifier.getFile(),
-                    identifier.getLine(),
-                    "Attempting to create variable '" + identifier.getText() + "' which already exists in scope");
+    public void createVariable(String identifier, JocksValue value) {
+        if (_variables.containsKey(identifier)) {
+            throw _exceptionFactory.createExceptionWithoutFileOrLine(
+                    "Attempting to create variable '" + identifier + "' which already exists in scope");
         }
-        _variables.put(identifier.getText(), value);
+        _variables.put(identifier, value);
     }
 
-    public JocksValue getVariable(Token identifier) {
-        if (!_variables.containsKey(identifier.getText())) {
+    public JocksValue getVariable(String identifier) {
+        if (!_variables.containsKey(identifier)) {
             if (_parent == null) {
-                throw _exceptionFactory.createExceptionWithFileAndLine(
-                        identifier.getFile(),
-                        identifier.getLine(),
-                        "Attempting to get variable '" + identifier.getText() + "' which doesn't exist");
+                throw _exceptionFactory.createExceptionWithoutFileOrLine(
+                        "Attempting to get variable '" + identifier + "' which doesn't exist");
             }
             return _parent.getVariable(identifier);
         } else {
-            return _variables.get(identifier.getText());
+            return _variables.get(identifier);
         }
     }
 
-    public void setVariable(Token identifier, JocksValue value) {
-        if (!_variables.containsKey(identifier.getText())) {
+    public void setVariable(String identifier, JocksValue value) {
+        if (!_variables.containsKey(identifier)) {
             if (_parent == null) {
-                throw _exceptionFactory.createExceptionWithFileAndLine(
-                        identifier.getFile(),
-                        identifier.getLine(),
-                        "Attempting to set variable '" + identifier.getText() + "' which doesn't exist");
+                throw _exceptionFactory.createExceptionWithoutFileOrLine(
+                        "Attempting to set variable '" + identifier + "' which doesn't exist");
             }
             _parent.setVariable(identifier, value);
         } else {
-            _variables.put(identifier.getText(), value);
+            _variables.put(identifier, value);
         }
     }
 

--- a/src/main/java/com/colossalg/visitors/SymbolTable.java
+++ b/src/main/java/com/colossalg/visitors/SymbolTable.java
@@ -23,7 +23,7 @@ public class SymbolTable {
 
     public void createVariable(Token identifier, JocksValue value) {
         if (_variables.containsKey(identifier.getText())) {
-            throw Interpreter.createException(
+            throw ExceptionFactory.createException(
                     identifier.getFile(),
                     identifier.getLine(),
                     "Attempting to create variable '" + identifier.getText() + "' which already exists in scope");
@@ -34,7 +34,7 @@ public class SymbolTable {
     public JocksValue getVariable(Token identifier) {
         if (!_variables.containsKey(identifier.getText())) {
             if (_parent == null) {
-                throw Interpreter.createException(
+                throw ExceptionFactory.createException(
                         identifier.getFile(),
                         identifier.getLine(),
                         "Attempting to get variable '" + identifier.getText() + "' which doesn't exist");
@@ -48,7 +48,7 @@ public class SymbolTable {
     public void setVariable(Token identifier, JocksValue value) {
         if (!_variables.containsKey(identifier.getText())) {
             if (_parent == null) {
-                throw Interpreter.createException(
+                throw ExceptionFactory.createException(
                         identifier.getFile(),
                         identifier.getLine(),
                         "Attempting to set variable '" + identifier.getText() + "' which doesn't exist");

--- a/test/add_bool.test
+++ b/test/add_bool.test
@@ -1,5 +1,7 @@
 print true + false;
 ---* EXPECT *---
-An internal error was encountered at runtime.
-Where - (D:\Jocks\test\add_bool.source:1)
-What  - Add (binary) is not implemented by com.colossalg.dataTypes.primitives.JocksBool
+Add (binary) is not implemented by com.colossalg.dataTypes.primitives.JocksBool
+
+	An internal runtime error was encountered (at line 1 of file 'D:\Jocks\test\add_bool.source').
+	Call stack:
+

--- a/test/add_instance_without_overload.test
+++ b/test/add_instance_without_overload.test
@@ -8,7 +8,10 @@ var p1 = new Point(1, 2);
 var p2 = new Point(1, 2);
 print p1 + p2;
 ---* EXPECT *---
-An internal error was encountered at runtime.
-Where - (D:\Jocks\test\add_instance_without_overload.source:9)
-What  - The '+' operator has not been overridden for the class 'Point' or any of its super classes.
-	Consider implementing the '__add__' method to fix this error.
+The '+' operator has not been overridden for the class 'Point' or any of its super classes.
+Consider implementing the '__add__' method to fix this error.
+
+	An internal runtime error was encountered (at line 9 of file 'D:\Jocks\test\add_instance_without_overload.source').
+	Call stack:
+		Point.__add__ at D:\Jocks\test\add_instance_without_overload.source:9
+

--- a/test/add_nil.test
+++ b/test/add_nil.test
@@ -1,5 +1,7 @@
 print nil + nil;
 ---* EXPECT *---
-An internal error was encountered at runtime.
-Where - (D:\Jocks\test\add_nil.source:1)
-What  - Add (binary) is not implemented by com.colossalg.dataTypes.primitives.JocksNil
+Add (binary) is not implemented by com.colossalg.dataTypes.primitives.JocksNil
+
+	An internal runtime error was encountered (at line 1 of file 'D:\Jocks\test\add_nil.source').
+	Call stack:
+

--- a/test/call_stack_in_error.test
+++ b/test/call_stack_in_error.test
@@ -1,0 +1,19 @@
+fun baz() {
+    print true + false; # This will cause an error.
+}
+fun bar() {
+    baz();
+}
+fun foo() {
+    bar();
+}
+foo();
+---* EXPECT *---
+Add (binary) is not implemented by com.colossalg.dataTypes.primitives.JocksBool
+
+	An internal runtime error was encountered (at line 2 of file 'D:\Jocks\test\call_stack_in_error.source').
+	Call stack:
+		foo at D:\Jocks\test\call_stack_in_error.source:10
+		bar at D:\Jocks\test\call_stack_in_error.source:8
+		baz at D:\Jocks\test\call_stack_in_error.source:5
+

--- a/test/div_bool.test
+++ b/test/div_bool.test
@@ -1,5 +1,7 @@
 print true / false;
 ---* EXPECT *---
-An internal error was encountered at runtime.
-Where - (D:\Jocks\test\div_bool.source:1)
-What  - Div is not implemented by com.colossalg.dataTypes.primitives.JocksBool
+Div is not implemented by com.colossalg.dataTypes.primitives.JocksBool
+
+	An internal runtime error was encountered (at line 1 of file 'D:\Jocks\test\div_bool.source').
+	Call stack:
+

--- a/test/div_instance_without_overload.test
+++ b/test/div_instance_without_overload.test
@@ -8,7 +8,10 @@ var p1 = new Point(1, 2);
 var p2 = new Point(1, 2);
 print p1 / p2;
 ---* EXPECT *---
-An internal error was encountered at runtime.
-Where - (D:\Jocks\test\div_instance_without_overload.source:9)
-What  - The '/' operator has not been overridden for the class 'Point' or any of its super classes.
-	Consider implementing the '__div__' method to fix this error.
+The '/' operator has not been overridden for the class 'Point' or any of its super classes.
+Consider implementing the '__div__' method to fix this error.
+
+	An internal runtime error was encountered (at line 9 of file 'D:\Jocks\test\div_instance_without_overload.source').
+	Call stack:
+		Point.__div__ at D:\Jocks\test\div_instance_without_overload.source:9
+

--- a/test/div_nil.test
+++ b/test/div_nil.test
@@ -1,5 +1,7 @@
 print nil / nil;
 ---* EXPECT *---
-An internal error was encountered at runtime.
-Where - (D:\Jocks\test\div_nil.source:1)
-What  - Div is not implemented by com.colossalg.dataTypes.primitives.JocksNil
+Div is not implemented by com.colossalg.dataTypes.primitives.JocksNil
+
+	An internal runtime error was encountered (at line 1 of file 'D:\Jocks\test\div_nil.source').
+	Call stack:
+

--- a/test/div_string.test
+++ b/test/div_string.test
@@ -1,5 +1,7 @@
 print "Hello" / "World";
 ---* EXPECT *---
-An internal error was encountered at runtime.
-Where - (D:\Jocks\test\div_string.source:1)
-What  - Div is not implemented by com.colossalg.dataTypes.primitives.JocksString
+Div is not implemented by com.colossalg.dataTypes.primitives.JocksString
+
+	An internal runtime error was encountered (at line 1 of file 'D:\Jocks\test\div_string.source').
+	Call stack:
+

--- a/test/equal_instance_without_overload.test
+++ b/test/equal_instance_without_overload.test
@@ -8,7 +8,10 @@ var p1 = new Point(1, 2);
 var p2 = new Point(1, 2);
 print p1 == p2;
 ---* EXPECT *---
-An internal error was encountered at runtime.
-Where - (D:\Jocks\test\equal_instance_without_overload.source:9)
-What  - The '==' operator has not been overridden for the class 'Point' or any of its super classes.
-	Consider implementing the '__equal__' method to fix this error.
+The '==' operator has not been overridden for the class 'Point' or any of its super classes.
+Consider implementing the '__equal__' method to fix this error.
+
+	An internal runtime error was encountered (at line 9 of file 'D:\Jocks\test\equal_instance_without_overload.source').
+	Call stack:
+		Point.__equal__ at D:\Jocks\test\equal_instance_without_overload.source:9
+

--- a/test/less_than_bool.test
+++ b/test/less_than_bool.test
@@ -1,5 +1,7 @@
 print true < false;
 ---* EXPECT *---
-An internal error was encountered at runtime.
-Where - (D:\Jocks\test\less_than_bool.source:1)
-What  - LessThan is not implemented by com.colossalg.dataTypes.primitives.JocksBool
+LessThan is not implemented by com.colossalg.dataTypes.primitives.JocksBool
+
+	An internal runtime error was encountered (at line 1 of file 'D:\Jocks\test\less_than_bool.source').
+	Call stack:
+

--- a/test/less_than_instance_without_overload.test
+++ b/test/less_than_instance_without_overload.test
@@ -8,7 +8,10 @@ var p1 = new Point(1, 2);
 var p2 = new Point(1, 2);
 print p1 < p2;
 ---* EXPECT *---
-An internal error was encountered at runtime.
-Where - (D:\Jocks\test\less_than_instance_without_overload.source:9)
-What  - The '<' operator has not been overridden for the class 'Point' or any of its super classes.
-	Consider implementing the '__less_than__' method to fix this error.
+The '<' operator has not been overridden for the class 'Point' or any of its super classes.
+Consider implementing the '__less_than__' method to fix this error.
+
+	An internal runtime error was encountered (at line 9 of file 'D:\Jocks\test\less_than_instance_without_overload.source').
+	Call stack:
+		Point.__less_than__ at D:\Jocks\test\less_than_instance_without_overload.source:9
+

--- a/test/less_than_nil.test
+++ b/test/less_than_nil.test
@@ -1,5 +1,7 @@
 print nil < nil;
 ---* EXPECT *---
-An internal error was encountered at runtime.
-Where - (D:\Jocks\test\less_than_nil.source:1)
-What  - LessThan is not implemented by com.colossalg.dataTypes.primitives.JocksNil
+LessThan is not implemented by com.colossalg.dataTypes.primitives.JocksNil
+
+	An internal runtime error was encountered (at line 1 of file 'D:\Jocks\test\less_than_nil.source').
+	Call stack:
+

--- a/test/less_than_or_equal_bool.test
+++ b/test/less_than_or_equal_bool.test
@@ -1,5 +1,7 @@
 print true <= false;
 ---* EXPECT *---
-An internal error was encountered at runtime.
-Where - (D:\Jocks\test\less_than_or_equal_bool.source:1)
-What  - LessThanOrEqual is not implemented by com.colossalg.dataTypes.primitives.JocksBool
+LessThanOrEqual is not implemented by com.colossalg.dataTypes.primitives.JocksBool
+
+	An internal runtime error was encountered (at line 1 of file 'D:\Jocks\test\less_than_or_equal_bool.source').
+	Call stack:
+

--- a/test/less_than_or_equal_instance_without_overload.test
+++ b/test/less_than_or_equal_instance_without_overload.test
@@ -8,7 +8,10 @@ var p1 = new Point(1, 2);
 var p2 = new Point(1, 2);
 print p1 <= p2;
 ---* EXPECT *---
-An internal error was encountered at runtime.
-Where - (D:\Jocks\test\less_than_or_equal_instance_without_overload.source:9)
-What  - The '<=' operator has not been overridden for the class 'Point' or any of its super classes.
-	Consider implementing the '__less_than_or_equal__' method to fix this error.
+The '<=' operator has not been overridden for the class 'Point' or any of its super classes.
+Consider implementing the '__less_than_or_equal__' method to fix this error.
+
+	An internal runtime error was encountered (at line 9 of file 'D:\Jocks\test\less_than_or_equal_instance_without_overload.source').
+	Call stack:
+		Point.__less_than_or_equal__ at D:\Jocks\test\less_than_or_equal_instance_without_overload.source:9
+

--- a/test/less_than_or_equal_nil.test
+++ b/test/less_than_or_equal_nil.test
@@ -1,5 +1,7 @@
 print nil <= nil;
 ---* EXPECT *---
-An internal error was encountered at runtime.
-Where - (D:\Jocks\test\less_than_or_equal_nil.source:1)
-What  - LessThanOrEqual is not implemented by com.colossalg.dataTypes.primitives.JocksNil
+LessThanOrEqual is not implemented by com.colossalg.dataTypes.primitives.JocksNil
+
+	An internal runtime error was encountered (at line 1 of file 'D:\Jocks\test\less_than_or_equal_nil.source').
+	Call stack:
+

--- a/test/less_than_or_equal_string.test
+++ b/test/less_than_or_equal_string.test
@@ -1,5 +1,7 @@
 print "Hello" <= "World";
 ---* EXPECT *---
-An internal error was encountered at runtime.
-Where - (D:\Jocks\test\less_than_or_equal_string.source:1)
-What  - LessThanOrEqual is not implemented by com.colossalg.dataTypes.primitives.JocksString
+LessThanOrEqual is not implemented by com.colossalg.dataTypes.primitives.JocksString
+
+	An internal runtime error was encountered (at line 1 of file 'D:\Jocks\test\less_than_or_equal_string.source').
+	Call stack:
+

--- a/test/less_than_string.test
+++ b/test/less_than_string.test
@@ -1,5 +1,7 @@
 print "Hello" < "World";
 ---* EXPECT *---
-An internal error was encountered at runtime.
-Where - (D:\Jocks\test\less_than_string.source:1)
-What  - LessThan is not implemented by com.colossalg.dataTypes.primitives.JocksString
+LessThan is not implemented by com.colossalg.dataTypes.primitives.JocksString
+
+	An internal runtime error was encountered (at line 1 of file 'D:\Jocks\test\less_than_string.source').
+	Call stack:
+

--- a/test/more_than_bool.test
+++ b/test/more_than_bool.test
@@ -1,5 +1,7 @@
 print true > false;
 ---* EXPECT *---
-An internal error was encountered at runtime.
-Where - (D:\Jocks\test\more_than_bool.source:1)
-What  - MoreThan is not implemented by com.colossalg.dataTypes.primitives.JocksBool
+MoreThan is not implemented by com.colossalg.dataTypes.primitives.JocksBool
+
+	An internal runtime error was encountered (at line 1 of file 'D:\Jocks\test\more_than_bool.source').
+	Call stack:
+

--- a/test/more_than_instance_without_overload.test
+++ b/test/more_than_instance_without_overload.test
@@ -8,7 +8,10 @@ var p1 = new Point(1, 2);
 var p2 = new Point(1, 2);
 print p1 > p2;
 ---* EXPECT *---
-An internal error was encountered at runtime.
-Where - (D:\Jocks\test\more_than_instance_without_overload.source:9)
-What  - The '>' operator has not been overridden for the class 'Point' or any of its super classes.
-	Consider implementing the '__more_than__' method to fix this error.
+The '>' operator has not been overridden for the class 'Point' or any of its super classes.
+Consider implementing the '__more_than__' method to fix this error.
+
+	An internal runtime error was encountered (at line 9 of file 'D:\Jocks\test\more_than_instance_without_overload.source').
+	Call stack:
+		Point.__more_than__ at D:\Jocks\test\more_than_instance_without_overload.source:9
+

--- a/test/more_than_nil.test
+++ b/test/more_than_nil.test
@@ -1,5 +1,7 @@
 print nil > nil;
 ---* EXPECT *---
-An internal error was encountered at runtime.
-Where - (D:\Jocks\test\more_than_nil.source:1)
-What  - MoreThan is not implemented by com.colossalg.dataTypes.primitives.JocksNil
+MoreThan is not implemented by com.colossalg.dataTypes.primitives.JocksNil
+
+	An internal runtime error was encountered (at line 1 of file 'D:\Jocks\test\more_than_nil.source').
+	Call stack:
+

--- a/test/more_than_or_equal_bool.test
+++ b/test/more_than_or_equal_bool.test
@@ -1,5 +1,7 @@
 print true >= false;
 ---* EXPECT *---
-An internal error was encountered at runtime.
-Where - (D:\Jocks\test\more_than_or_equal_bool.source:1)
-What  - MoreThanOrEqual is not implemented by com.colossalg.dataTypes.primitives.JocksBool
+MoreThanOrEqual is not implemented by com.colossalg.dataTypes.primitives.JocksBool
+
+	An internal runtime error was encountered (at line 1 of file 'D:\Jocks\test\more_than_or_equal_bool.source').
+	Call stack:
+

--- a/test/more_than_or_equal_instance_without_overload.test
+++ b/test/more_than_or_equal_instance_without_overload.test
@@ -8,7 +8,10 @@ var p1 = new Point(1, 2);
 var p2 = new Point(1, 2);
 print p1 >= p2;
 ---* EXPECT *---
-An internal error was encountered at runtime.
-Where - (D:\Jocks\test\more_than_or_equal_instance_without_overload.source:9)
-What  - The '>=' operator has not been overridden for the class 'Point' or any of its super classes.
-	Consider implementing the '__more_than_or_equal__' method to fix this error.
+The '>=' operator has not been overridden for the class 'Point' or any of its super classes.
+Consider implementing the '__more_than_or_equal__' method to fix this error.
+
+	An internal runtime error was encountered (at line 9 of file 'D:\Jocks\test\more_than_or_equal_instance_without_overload.source').
+	Call stack:
+		Point.__more_than_or_equal__ at D:\Jocks\test\more_than_or_equal_instance_without_overload.source:9
+

--- a/test/more_than_or_equal_nil.test
+++ b/test/more_than_or_equal_nil.test
@@ -1,5 +1,7 @@
 print nil >= nil;
 ---* EXPECT *---
-An internal error was encountered at runtime.
-Where - (D:\Jocks\test\more_than_or_equal_nil.source:1)
-What  - MoreThanOrEqual is not implemented by com.colossalg.dataTypes.primitives.JocksNil
+MoreThanOrEqual is not implemented by com.colossalg.dataTypes.primitives.JocksNil
+
+	An internal runtime error was encountered (at line 1 of file 'D:\Jocks\test\more_than_or_equal_nil.source').
+	Call stack:
+

--- a/test/more_than_or_equal_string.test
+++ b/test/more_than_or_equal_string.test
@@ -1,5 +1,7 @@
 print "Hello" >= "World";
 ---* EXPECT *---
-An internal error was encountered at runtime.
-Where - (D:\Jocks\test\more_than_or_equal_string.source:1)
-What  - MoreThanOrEqual is not implemented by com.colossalg.dataTypes.primitives.JocksString
+MoreThanOrEqual is not implemented by com.colossalg.dataTypes.primitives.JocksString
+
+	An internal runtime error was encountered (at line 1 of file 'D:\Jocks\test\more_than_or_equal_string.source').
+	Call stack:
+

--- a/test/more_than_string.test
+++ b/test/more_than_string.test
@@ -1,5 +1,7 @@
 print "Hello" > "World";
 ---* EXPECT *---
-An internal error was encountered at runtime.
-Where - (D:\Jocks\test\more_than_string.source:1)
-What  - MoreThan is not implemented by com.colossalg.dataTypes.primitives.JocksString
+MoreThan is not implemented by com.colossalg.dataTypes.primitives.JocksString
+
+	An internal runtime error was encountered (at line 1 of file 'D:\Jocks\test\more_than_string.source').
+	Call stack:
+

--- a/test/mul_bool.test
+++ b/test/mul_bool.test
@@ -1,5 +1,7 @@
 print true * false;
 ---* EXPECT *---
-An internal error was encountered at runtime.
-Where - (D:\Jocks\test\mul_bool.source:1)
-What  - Mul is not implemented by com.colossalg.dataTypes.primitives.JocksBool
+Mul is not implemented by com.colossalg.dataTypes.primitives.JocksBool
+
+	An internal runtime error was encountered (at line 1 of file 'D:\Jocks\test\mul_bool.source').
+	Call stack:
+

--- a/test/mul_instance_without_overload.test
+++ b/test/mul_instance_without_overload.test
@@ -8,7 +8,10 @@ var p1 = new Point(1, 2);
 var p2 = new Point(1, 2);
 print p1 * p2;
 ---* EXPECT *---
-An internal error was encountered at runtime.
-Where - (D:\Jocks\test\mul_instance_without_overload.source:9)
-What  - The '*' operator has not been overridden for the class 'Point' or any of its super classes.
-	Consider implementing the '__mul__' method to fix this error.
+The '*' operator has not been overridden for the class 'Point' or any of its super classes.
+Consider implementing the '__mul__' method to fix this error.
+
+	An internal runtime error was encountered (at line 9 of file 'D:\Jocks\test\mul_instance_without_overload.source').
+	Call stack:
+		Point.__mul__ at D:\Jocks\test\mul_instance_without_overload.source:9
+

--- a/test/mul_nil.test
+++ b/test/mul_nil.test
@@ -1,5 +1,7 @@
 print nil * nil;
 ---* EXPECT *---
-An internal error was encountered at runtime.
-Where - (D:\Jocks\test\mul_nil.source:1)
-What  - Mul is not implemented by com.colossalg.dataTypes.primitives.JocksNil
+Mul is not implemented by com.colossalg.dataTypes.primitives.JocksNil
+
+	An internal runtime error was encountered (at line 1 of file 'D:\Jocks\test\mul_nil.source').
+	Call stack:
+

--- a/test/mul_string.test
+++ b/test/mul_string.test
@@ -1,5 +1,7 @@
 print "Hello" * "World";
 ---* EXPECT *---
-An internal error was encountered at runtime.
-Where - (D:\Jocks\test\mul_string.source:1)
-What  - Mul is not implemented by com.colossalg.dataTypes.primitives.JocksString
+Mul is not implemented by com.colossalg.dataTypes.primitives.JocksString
+
+	An internal runtime error was encountered (at line 1 of file 'D:\Jocks\test\mul_string.source').
+	Call stack:
+

--- a/test/not_equal_instance_without_overload.test
+++ b/test/not_equal_instance_without_overload.test
@@ -8,7 +8,10 @@ var p1 = new Point(1, 2);
 var p2 = new Point(1, 2);
 print p1 != p2;
 ---* EXPECT *---
-An internal error was encountered at runtime.
-Where - (D:\Jocks\test\not_equal_instance_without_overload.source:9)
-What  - The '!=' operator has not been overridden for the class 'Point' or any of its super classes.
-	Consider implementing the '__not_equal__' method to fix this error.
+The '!=' operator has not been overridden for the class 'Point' or any of its super classes.
+Consider implementing the '__not_equal__' method to fix this error.
+
+	An internal runtime error was encountered (at line 9 of file 'D:\Jocks\test\not_equal_instance_without_overload.source').
+	Call stack:
+		Point.__not_equal__ at D:\Jocks\test\not_equal_instance_without_overload.source:9
+

--- a/test/print_function_from_java_land.test
+++ b/test/print_function_from_java_land.test
@@ -1,3 +1,3 @@
-print isNil;
+print is_nil;
 ---* EXPECT *---
-JocksJavaLandFunction
+JocksJavaLandFunction(is_nil)

--- a/test/print_function_from_user_land.test
+++ b/test/print_function_from_user_land.test
@@ -3,4 +3,4 @@ fun dummy() {
 }
 print dummy;
 ---* EXPECT *---
-JocksUserLandFunction
+JocksUserLandFunction(dummy)

--- a/test/print_method.test
+++ b/test/print_method.test
@@ -1,0 +1,15 @@
+class Person {
+    fun __init__(self, first_name, last_name) {
+        self.first_name = first_name;
+        self.last_name = last_name;
+    }
+    fun get_full_name(self) {
+        return self.first_name + " " + self.last_name;
+    }
+}
+var p = new Person("John", "Doe");
+print Person.get_full_name;
+print p.get_full_name;
+---* EXPECT *---
+JocksUserLandFunction(Person.get_full_name)
+BoundMethod(JocksUserLandFunction(Person.get_full_name))

--- a/test/sub_bool.test
+++ b/test/sub_bool.test
@@ -1,5 +1,7 @@
 print true - false;
 ---* EXPECT *---
-An internal error was encountered at runtime.
-Where - (D:\Jocks\test\sub_bool.source:1)
-What  - Sub (binary) is not implemented by com.colossalg.dataTypes.primitives.JocksBool
+Sub (binary) is not implemented by com.colossalg.dataTypes.primitives.JocksBool
+
+	An internal runtime error was encountered (at line 1 of file 'D:\Jocks\test\sub_bool.source').
+	Call stack:
+

--- a/test/sub_instance_without_overload.test
+++ b/test/sub_instance_without_overload.test
@@ -8,7 +8,10 @@ var p1 = new Point(1, 2);
 var p2 = new Point(1, 2);
 print p1 - p2;
 ---* EXPECT *---
-An internal error was encountered at runtime.
-Where - (D:\Jocks\test\sub_instance_without_overload.source:9)
-What  - The '-' operator has not been overridden for the class 'Point' or any of its super classes.
-	Consider implementing the '__sub__' method to fix this error.
+The '-' operator has not been overridden for the class 'Point' or any of its super classes.
+Consider implementing the '__sub__' method to fix this error.
+
+	An internal runtime error was encountered (at line 9 of file 'D:\Jocks\test\sub_instance_without_overload.source').
+	Call stack:
+		Point.__sub__ at D:\Jocks\test\sub_instance_without_overload.source:9
+

--- a/test/sub_nil.test
+++ b/test/sub_nil.test
@@ -1,5 +1,7 @@
 print nil - nil;
 ---* EXPECT *---
-An internal error was encountered at runtime.
-Where - (D:\Jocks\test\sub_nil.source:1)
-What  - Sub (binary) is not implemented by com.colossalg.dataTypes.primitives.JocksNil
+Sub (binary) is not implemented by com.colossalg.dataTypes.primitives.JocksNil
+
+	An internal runtime error was encountered (at line 1 of file 'D:\Jocks\test\sub_nil.source').
+	Call stack:
+

--- a/test/sub_string.test
+++ b/test/sub_string.test
@@ -1,5 +1,7 @@
 print "Hello" - "World";
 ---* EXPECT *---
-An internal error was encountered at runtime.
-Where - (D:\Jocks\test\sub_string.source:1)
-What  - Sub (binary) is not implemented by com.colossalg.dataTypes.primitives.JocksString
+Sub (binary) is not implemented by com.colossalg.dataTypes.primitives.JocksString
+
+	An internal runtime error was encountered (at line 1 of file 'D:\Jocks\test\sub_string.source').
+	Call stack:
+


### PR DESCRIPTION
This PR records the call stack so that localization of the error in the error messages printed to the screen is much better.

A side effect of this, is that with the call stack, I was confident that the error localization was sufficient enough that I could revert some changes made prior to add the file/line to the representation of every `Statement` and `Expression` sub class. I never really liked having to add this, and for most sub-classes that information was redundant as they had a `Token` either for an operator or identifier anyways (which contain the file/line in source). As a result, a few messages now don't have the exact file/line they were caused, but this should be fine, as the call stack will at least lead the user to the function it was caused in, and narrow down most of the search. The code has benefitted from this simplification.

Similarly, the `SymbolTable`, `JocksClass` identifier, and `JocksUserLandFunction` parameters use strings again. I never liked using `Token` in these places, as it felt like an abstraction from the static phases of the interpretation process leaking into the runtime representation. The errors from lookup in the `SymbolTable` refer to creating/setting/getting variables in the current chain of scopes. With the call stack, it should be obvious where is being referred to, and exact file/line didn't add much. Again, the code could benefit from this simplification.