### PR TITLE
Remove requirement that classes are defined at global scope

### DIFF
--- a/src/main/java/com/colossalg/visitors/Resolver.java
+++ b/src/main/java/com/colossalg/visitors/Resolver.java
@@ -49,15 +49,6 @@ public class Resolver implements StatementVisitor<Void>, ExpressionVisitor<Void>
     }
 
     public Void visitClassDeclaration(ClassDeclaration statement) {
-        if (_scopes.size() != 1) {
-            _errorReporter.report(
-                    new JocksError(
-                        "Resolver",
-                        statement.getIdentifier().getFile(),
-                        statement.getIdentifier().getLine(),
-                        "Class declarations are only allowed at the global scope."));
-        }
-
         declareAndDefine(statement.getIdentifier());
 
         if (statement.getSuperClass().isPresent()) {

--- a/test/inheritance_scoping.test
+++ b/test/inheritance_scoping.test
@@ -1,0 +1,48 @@
+class A {
+    fun some_method(self) {
+        print "Outer A.";
+    }
+}
+class B < A {
+    fun test(self) {
+        self.some_method();
+    }
+}
+# Test the usual case.
+{
+    var b = new B();
+    b.test();
+}
+# Test the case where super class has been redefined inside a scope.
+# B should still refer to the definition of A from when it was
+# defined itself (i.e. super class is not dynamically scoped).
+{
+    class A {
+        fun some_method(self) {
+            print "Inner A (1).";
+        }
+    }
+    var b = new B();
+    b.test();
+}
+# Test the case where we redefine B too to derive from a nested definition
+# of A. In this case the super class should be the redefined A as that is
+# the appropriate definition of A at the time of B's definition.
+{
+    class A {
+        fun some_method(self) {
+            print "Inner A (2).";
+        }
+    }
+    class B < A {
+        fun test(self) {
+            self.some_method();
+        }
+    }
+    var b = new B();
+    b.test();
+}
+---* EXPECT *---
+Outer A.
+Outer A.
+Inner A (2).


### PR DESCRIPTION
In https://github.com/colossalg/Jocks/pull/4 I changed the code so that classes point to their super class via a Java reference, not a string, in their runtime representation. A very positive side effect of this is that class definitions no longer are dynamically scoped. As such, restricting class definitions to the global scope (in the `Resolver`) doesn't make sense anymore. I've removed the code enforcing this and added a test for the scoping of class definitions.

The code is now more consistent. Variables, functions and classes can be defined at any scope even if they shadow definitions in the outer scope. All scoping is lexical, however, so usage follows what would be expected. I'm not aware of any remaining edge cases.