### PR TITLE
Fix uncaught exception handling

### DIFF
--- a/src/main/java/com/colossalg/Jocks.java
+++ b/src/main/java/com/colossalg/Jocks.java
@@ -90,6 +90,10 @@ public class Jocks {
         try {
             final var interpreter = new Interpreter();
             interpreter.visitAll(statements);
+            if (interpreter.getIsThrowing()) {
+                System.out.println("ERROR - Program terminating with uncaught thrown value.");
+                System.out.println("\tConsider adding a top level try/catch block to log the exception.");
+            }
         } catch (RuntimeException ex) {
             System.out.println(ex.getMessage());
         }

--- a/src/main/java/com/colossalg/visitors/Interpreter.java
+++ b/src/main/java/com/colossalg/visitors/Interpreter.java
@@ -594,6 +594,10 @@ public class Interpreter implements StatementVisitor<Void>, ExpressionVisitor<Jo
         return result;
     }
 
+    public boolean getIsThrowing() {
+        return _isThrowing;
+    }
+
     private void pushCallStackEntryInfo(String name, String line, int file) {
         _callStackEntryInfo.addLast(String.format("%s at %s:%d", name, line, file));
     }

--- a/test/uncaught_exception.test
+++ b/test/uncaught_exception.test
@@ -1,0 +1,12 @@
+class Exception {
+    fun __init__(self, what) {
+        self.what = what;
+    }
+}
+fun foo() {
+    throw new Exception("Thrown from bar().");
+}
+foo();
+---* EXPECT *---
+ERROR - Program terminating with uncaught thrown value.
+	Consider adding a top level try/catch block to log the exception.


### PR DESCRIPTION
This PR warns the user if the program exits with a thrown value that has not been caught.
In this instance they should probably add a top-level catch/try block.